### PR TITLE
Import in place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ coverage/
 # Stryker
 .stryker-tmp
 reports/
+
+# Task reviews (branch-scoped, ephemeral)
+reviews/

--- a/e2e-tests/core.spec.ts
+++ b/e2e-tests/core.spec.ts
@@ -67,6 +67,7 @@ test.describe('Article Importing', () => {
     await window.getByText('Import article').click();
     await finalizeArticleImport(window);
 
+    await executeCommandById(window, 'incremental-reading:learn');
     // look for the action bar to confirm we're in review
     await expect(
       window.getByRole('button', { name: 'Mark as reviewed' })

--- a/e2e-tests/core.spec.ts
+++ b/e2e-tests/core.spec.ts
@@ -272,11 +272,6 @@ test.describe('Action Bar', () => {
     await executeCommandById(window, 'incremental-reading:import-article');
     await finalizeArticleImport(window);
 
-    await openNote(
-      window,
-      'incremental-reading/articles/Memorizing a programming language using spaced repetition'
-    );
-
     const dismissButton = window.getByRole('button', {
       name: 'Dismiss',
     });
@@ -301,11 +296,6 @@ test.describe('Action Bar', () => {
 
     await executeCommandById(window, 'incremental-reading:import-article');
     await finalizeArticleImport(window);
-
-    await openNote(
-      window,
-      'incremental-reading/articles/Memorizing a programming language using spaced repetition'
-    );
 
     const dismissButton = window.getByRole('button', {
       name: 'Dismiss',

--- a/src/components/ImportModalContent.tsx
+++ b/src/components/ImportModalContent.tsx
@@ -1,0 +1,129 @@
+import {
+  MAXIMUM_FIXED_REVIEW_INTERVAL,
+  MAXIMUM_PRIORITY,
+  MINIMUM_FIXED_REVIEW_INTERVAL,
+  MINIMUM_PRIORITY,
+} from '#/lib/constants';
+import IRScheduler from '#/lib/IRScheduler';
+import type { SchedulingStrategy } from '#/lib/types';
+import { useState } from 'react';
+import { FixedIntervalField } from './action-bar/FixedIntervalField';
+import { PriorityField } from './action-bar/PriorityField';
+import type { ImportModalProps } from './types';
+
+export function ImportModalContent({
+  plugin,
+  schedule,
+  defaultCopyOnImport,
+  onClose,
+}: ImportModalProps) {
+  const [strategy, setStrategy] = useState<SchedulingStrategy>('priority');
+  const [makeCopy, setMakeCopy] = useState(defaultCopyOnImport);
+  const [scheduleValues, setScheduleValues] = useState({
+    priority: schedule.priority ?? plugin.settings.defaultPriority,
+    fixedIntervalDays: schedule.intervalDays ?? MINIMUM_FIXED_REVIEW_INTERVAL,
+  });
+
+  const updateValues = (updates: Partial<typeof scheduleValues>) => {
+    setScheduleValues((prev) => ({ ...prev, ...updates }));
+  };
+
+  const handleEnter = () => {
+    const value =
+      strategy === 'priority'
+        ? scheduleValues.priority
+        : scheduleValues.fixedIntervalDays;
+    onClose({ strategy, value, makeCopy });
+  };
+
+  const intervalTooltip =
+    `Number of days between reviews, from ` +
+    `${MINIMUM_FIXED_REVIEW_INTERVAL} to ${MAXIMUM_FIXED_REVIEW_INTERVAL}.`;
+
+  const prioTooltip =
+    `Priority is used to grow the time to the next review. Ranges from ` +
+    `${IRScheduler.toDisplayPriority(MINIMUM_PRIORITY)} (slow growth, more frequent review) to ` +
+    `${IRScheduler.toDisplayPriority(MAXIMUM_PRIORITY)} (fast growth, less frequent review).`;
+
+  return (
+    <div
+      className="ir-scheduling-modal"
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          handleEnter();
+        }
+      }}
+    >
+      <div className="ir-toggle">
+        <label className="ir-toggle-label">
+          Fixed intervals
+          <div
+            className={
+              'checkbox-container' +
+              (strategy === 'priority' ? ' is-enabled' : '')
+            }
+          >
+            <input
+              type="checkbox"
+              checked={strategy === 'priority'}
+              onChange={(e) =>
+                setStrategy(
+                  e.currentTarget.checked ? 'priority' : 'fixed-interval'
+                )
+              }
+            />
+          </div>
+          Priority scheduling
+        </label>
+      </div>
+      {strategy === 'priority' ? (
+        <>
+          <PriorityField
+            initialPriority={scheduleValues.priority}
+            onBlur={(priority: number) => updateValues({ priority })}
+            showMultiplier
+          />
+          <div className="ir-scheduling-tooltip">{prioTooltip}</div>
+        </>
+      ) : (
+        <>
+          <FixedIntervalField
+            initialInterval={schedule.intervalDays}
+            onBlur={(intervalDays: number) =>
+              updateValues({ fixedIntervalDays: intervalDays })
+            }
+          />
+          <div className="ir-scheduling-tooltip">{intervalTooltip}</div>
+        </>
+      )}
+      <div className="ir-toggle">
+        <label className="ir-toggle-label">
+          Import in place
+          <div
+            className={'checkbox-container' + (makeCopy ? ' is-enabled' : '')}
+          >
+            <input
+              type="checkbox"
+              checked={makeCopy}
+              onChange={(e) => setMakeCopy(e.currentTarget.checked)}
+            />
+          </div>
+          Make a copy
+        </label>
+      </div>
+      <div className="modal-button-container">
+        <button
+          onClick={() => {
+            onClose('cancel');
+          }}
+        >
+          Cancel
+        </button>
+        <button onClick={handleEnter} className="mod-cta">
+          Confirm
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/action-bar/FixedIntervalField.tsx
+++ b/src/components/action-bar/FixedIntervalField.tsx
@@ -3,7 +3,7 @@ import {
   MINIMUM_FIXED_REVIEW_INTERVAL,
 } from '#/lib/constants';
 import IRScheduler from '#/lib/IRScheduler';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export function FixedIntervalField({
   initialInterval,
@@ -14,6 +14,20 @@ export function FixedIntervalField({
 }) {
   const [fixedInterval, setFixedInterval] = useState<number>(
     initialInterval ?? MINIMUM_FIXED_REVIEW_INTERVAL
+  );
+  const prevIntervalRef = useRef(initialInterval);
+
+  useEffect(
+    function updateIntervalOnRerender() {
+      if (
+        initialInterval !== null &&
+        prevIntervalRef.current !== initialInterval
+      ) {
+        prevIntervalRef.current = initialInterval;
+        setFixedInterval(initialInterval);
+      }
+    },
+    [initialInterval]
   );
 
   return (
@@ -41,6 +55,7 @@ export function FixedIntervalField({
               }
             }}
             onBlur={() => {
+              prevIntervalRef.current = fixedInterval;
               void onBlur(fixedInterval);
             }}
             onKeyDown={(e) => {

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -28,3 +28,17 @@ export interface SchedulingModalProps {
     args: 'cancel' | { strategy: SchedulingStrategy; value: number }
   ) => void;
 }
+
+export interface ImportModalProps {
+  plugin: IncrementalReadingPlugin;
+  schedule: {
+    intervalDays: number | null;
+    priority: number;
+  };
+  defaultCopyOnImport: boolean;
+  onClose: (
+    args:
+      | 'cancel'
+      | { strategy: SchedulingStrategy; value: number; makeCopy: boolean }
+  ) => void;
+}

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -1,4 +1,5 @@
 import {
+  DATA_DIRECTORY,
   MAXIMUM_PRIORITY,
   MINIMUM_PRIORITY,
   MS_PER_DAY,
@@ -231,7 +232,7 @@ describe('migration v1 — add start_offset and end_offset to snippet', () => {
     applyMigrations(db, migrations);
     const rows = selectAll(db, 'snippet');
     expect(rows).toHaveLength(1);
-    expect(rows[0].reference).toBe('note.md#snippet-1');
+    expect(rows[0].reference).toBe(`${DATA_DIRECTORY}/note.md#snippet-1`);
     expect(rows[0].start_offset).toBeNull();
     expect(rows[0].end_offset).toBeNull();
   });
@@ -271,6 +272,91 @@ describe('migration v2 — add scroll_top to article and snippet', () => {
     expect(rows[0].scroll_top).toBe(0);
   });
 });
+
+/** Schema state after migration v5 (has deleted column on all item tables) */
+const SCHEMA_V5 = `
+  CREATE TABLE article (
+    id TEXT NOT NULL,
+    reference TEXT NOT NULL UNIQUE,
+    due INTEGER,
+    interval INTEGER NOT NULL,
+    priority INTEGER NOT NULL,
+    fixed_interval_days INTEGER NULL,
+    dismissed INTEGER NOT NULL DEFAULT FALSE,
+    deleted INTEGER NOT NULL DEFAULT FALSE,
+    scroll_top INTEGER NOT NULL DEFAULT 0,
+    CHECK(interval > 0),
+    CHECK(priority >= 10 AND priority <= 50),
+    CHECK(fixed_interval_days > 0),
+    CHECK(dismissed = FALSE OR dismissed = TRUE),
+    CHECK(deleted = FALSE OR deleted = TRUE),
+    CHECK(due IS NOT NULL OR dismissed = TRUE)
+  );
+  CREATE TABLE snippet (
+    id TEXT NOT NULL,
+    reference TEXT NOT NULL UNIQUE,
+    parent TEXT DEFAULT NULL,
+    due INTEGER,
+    interval INTEGER NOT NULL,
+    priority INTEGER NOT NULL,
+    dismissed INTEGER NOT NULL DEFAULT FALSE,
+    deleted INTEGER NOT NULL DEFAULT FALSE,
+    scroll_top INTEGER NOT NULL DEFAULT 0,
+    start_offset INTEGER DEFAULT NULL,
+    end_offset INTEGER DEFAULT NULL,
+    CHECK(interval > 0),
+    CHECK(priority >= 10 AND priority <= 50),
+    CHECK(dismissed = FALSE OR dismissed = TRUE),
+    CHECK(deleted = FALSE OR deleted = TRUE),
+    CHECK(due IS NOT NULL OR dismissed = TRUE)
+  );
+  CREATE TABLE srs_card (
+    id TEXT NOT NULL,
+    reference TEXT NOT NULL UNIQUE,
+    parent TEXT DEFAULT NULL,
+    created_at INTEGER NOT NULL,
+    due INTEGER NOT NULL,
+    dismissed INTEGER NOT NULL DEFAULT FALSE,
+    deleted INTEGER NOT NULL DEFAULT FALSE,
+    last_review INTEGER,
+    stability REAL NOT NULL,
+    difficulty REAL NOT NULL,
+    elapsed_days REAL NOT NULL,
+    scheduled_days REAL NOT NULL,
+    reps INTEGER NOT NULL DEFAULT 0,
+    lapses INTEGER NOT NULL DEFAULT 0,
+    state INTEGER NOT NULL,
+    CHECK(state >= 0 AND state <= 3),
+    CHECK(dismissed = FALSE OR dismissed = TRUE),
+    CHECK(deleted = FALSE OR deleted = TRUE)
+  );
+  CREATE TABLE article_review (
+    id TEXT NOT NULL,
+    article_id TEXT NOT NULL REFERENCES article(id),
+    review_time INTEGER NOT NULL
+  );
+  CREATE TABLE snippet_review (
+    id TEXT NOT NULL,
+    snippet_id TEXT NOT NULL REFERENCES snippet(id),
+    review_time INTEGER NOT NULL
+  );
+  CREATE TABLE srs_card_review (
+    id TEXT NOT NULL,
+    card_id TEXT NOT NULL REFERENCES srs_card(id),
+    due INTEGER NOT NULL,
+    review INTEGER NOT NULL,
+    stability REAL NOT NULL,
+    difficulty REAL NOT NULL,
+    elapsed_days REAL NOT NULL,
+    last_elapsed_days REAL NOT NULL,
+    scheduled_days REAL NOT NULL,
+    rating INTEGER NOT NULL,
+    state INTEGER NOT NULL,
+    CHECK(state >= 0 AND state <= 3),
+    CHECK(rating >= 0 AND rating <= 4)
+  );
+  PRAGMA user_version = 5;
+`;
 
 // ---------------------------------------------------------------------------
 // Migration v3 tests
@@ -391,7 +477,7 @@ describe('migration v3 — backfill interval on article and snippet', () => {
     const rows = selectAll(db, 'article');
     expect(rows[0]).toEqual({
       id: 'a1',
-      reference: 'article.md',
+      reference: `${DATA_DIRECTORY}/article.md`,
       due: 999,
       interval: MS_PER_DAY,
       priority: 40,
@@ -570,5 +656,75 @@ describe('recreateTable', () => {
     });
     const fkResult = db.exec('PRAGMA foreign_keys');
     expect(fkResult[0].values[0][0]).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration v6 tests
+// ---------------------------------------------------------------------------
+
+describe('migration v6 — vault-relative references', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = makeDb(SCHEMA_V5);
+    db.exec(`INSERT INTO article (id, reference, due, interval, priority)
+      VALUES ('a1', 'articles/article.md', 1000, 86400000, 30)`);
+    db.exec(`INSERT INTO snippet (id, reference, parent, due, interval, priority)
+      VALUES ('s1', 'snippets/snip.md', 'articles/article.md', 1000, 86400000, 20)`);
+    db.exec(`INSERT INTO snippet (id, reference, parent, due, interval, priority)
+      VALUES ('s2', 'snippets/snip-frag.md#h1', NULL, 1000, 86400000, 20)`);
+    db.exec(`INSERT INTO srs_card
+      (id, reference, parent, created_at, due, stability, difficulty, elapsed_days, scheduled_days, state)
+      VALUES ('c1', 'cards/card.md', 'articles/article.md', 0, 1000, 1.0, 1.0, 0.0, 1.0, 0)`);
+  });
+
+  it('prefixes article references with DATA_DIRECTORY/', () => {
+    applyMigrations(db, migrations);
+    const rows = selectAll(db, 'article');
+    expect(rows[0].reference).toBe(`${DATA_DIRECTORY}/articles/article.md`);
+  });
+
+  it('prefixes snippet references with DATA_DIRECTORY/', () => {
+    applyMigrations(db, migrations);
+    const byId = Object.fromEntries(selectAll(db, 'snippet').map((r) => [r.id, r]));
+    expect(byId['s1'].reference).toBe(`${DATA_DIRECTORY}/snippets/snip.md`);
+  });
+
+  it('preserves #fragment suffix when prefixing snippet references', () => {
+    applyMigrations(db, migrations);
+    const byId = Object.fromEntries(selectAll(db, 'snippet').map((r) => [r.id, r]));
+    expect(byId['s2'].reference).toBe(`${DATA_DIRECTORY}/snippets/snip-frag.md#h1`);
+  });
+
+  it('prefixes srs_card references with DATA_DIRECTORY/', () => {
+    applyMigrations(db, migrations);
+    const rows = selectAll(db, 'srs_card');
+    expect(rows[0].reference).toBe(`${DATA_DIRECTORY}/cards/card.md`);
+  });
+
+  it('prefixes non-null snippet.parent with DATA_DIRECTORY/', () => {
+    applyMigrations(db, migrations);
+    const byId = Object.fromEntries(selectAll(db, 'snippet').map((r) => [r.id, r]));
+    expect(byId['s1'].parent).toBe(`${DATA_DIRECTORY}/articles/article.md`);
+    expect(byId['s2'].parent).toBeNull();
+  });
+
+  it('prefixes non-null srs_card.parent with DATA_DIRECTORY/', () => {
+    applyMigrations(db, migrations);
+    const rows = selectAll(db, 'srs_card');
+    expect(rows[0].parent).toBe(`${DATA_DIRECTORY}/articles/article.md`);
+  });
+
+  it('leaves row counts unchanged', () => {
+    applyMigrations(db, migrations);
+    expect(selectAll(db, 'article')).toHaveLength(1);
+    expect(selectAll(db, 'snippet')).toHaveLength(2);
+    expect(selectAll(db, 'srs_card')).toHaveLength(1);
+  });
+
+  it('advances schema version to 6', () => {
+    applyMigrations(db, migrations);
+    expect(getSchemaVersion(db)).toBe(6);
   });
 });

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -133,6 +133,91 @@ const SCHEMA_V0 = `
   PRAGMA user_version = 0;
 `;
 
+/** Schema state after migration v5 (has deleted column on all item tables) */
+const SCHEMA_V5 = `
+  CREATE TABLE article (
+    id TEXT NOT NULL,
+    reference TEXT NOT NULL UNIQUE,
+    due INTEGER,
+    interval INTEGER NOT NULL,
+    priority INTEGER NOT NULL,
+    fixed_interval_days INTEGER NULL,
+    dismissed INTEGER NOT NULL DEFAULT FALSE,
+    deleted INTEGER NOT NULL DEFAULT FALSE,
+    scroll_top INTEGER NOT NULL DEFAULT 0,
+    CHECK(interval > 0),
+    CHECK(priority >= 10 AND priority <= 50),
+    CHECK(fixed_interval_days > 0),
+    CHECK(dismissed = FALSE OR dismissed = TRUE),
+    CHECK(deleted = FALSE OR deleted = TRUE),
+    CHECK(due IS NOT NULL OR dismissed = TRUE)
+  );
+  CREATE TABLE snippet (
+    id TEXT NOT NULL,
+    reference TEXT NOT NULL UNIQUE,
+    parent TEXT DEFAULT NULL,
+    due INTEGER,
+    interval INTEGER NOT NULL,
+    priority INTEGER NOT NULL,
+    dismissed INTEGER NOT NULL DEFAULT FALSE,
+    deleted INTEGER NOT NULL DEFAULT FALSE,
+    scroll_top INTEGER NOT NULL DEFAULT 0,
+    start_offset INTEGER DEFAULT NULL,
+    end_offset INTEGER DEFAULT NULL,
+    CHECK(interval > 0),
+    CHECK(priority >= 10 AND priority <= 50),
+    CHECK(dismissed = FALSE OR dismissed = TRUE),
+    CHECK(deleted = FALSE OR deleted = TRUE),
+    CHECK(due IS NOT NULL OR dismissed = TRUE)
+  );
+  CREATE TABLE srs_card (
+    id TEXT NOT NULL,
+    reference TEXT NOT NULL UNIQUE,
+    parent TEXT DEFAULT NULL,
+    created_at INTEGER NOT NULL,
+    due INTEGER NOT NULL,
+    dismissed INTEGER NOT NULL DEFAULT FALSE,
+    deleted INTEGER NOT NULL DEFAULT FALSE,
+    last_review INTEGER,
+    stability REAL NOT NULL,
+    difficulty REAL NOT NULL,
+    elapsed_days REAL NOT NULL,
+    scheduled_days REAL NOT NULL,
+    reps INTEGER NOT NULL DEFAULT 0,
+    lapses INTEGER NOT NULL DEFAULT 0,
+    state INTEGER NOT NULL,
+    CHECK(state >= 0 AND state <= 3),
+    CHECK(dismissed = FALSE OR dismissed = TRUE),
+    CHECK(deleted = FALSE OR deleted = TRUE)
+  );
+  CREATE TABLE article_review (
+    id TEXT NOT NULL,
+    article_id TEXT NOT NULL REFERENCES article(id),
+    review_time INTEGER NOT NULL
+  );
+  CREATE TABLE snippet_review (
+    id TEXT NOT NULL,
+    snippet_id TEXT NOT NULL REFERENCES snippet(id),
+    review_time INTEGER NOT NULL
+  );
+  CREATE TABLE srs_card_review (
+    id TEXT NOT NULL,
+    card_id TEXT NOT NULL REFERENCES srs_card(id),
+    due INTEGER NOT NULL,
+    review INTEGER NOT NULL,
+    stability REAL NOT NULL,
+    difficulty REAL NOT NULL,
+    elapsed_days REAL NOT NULL,
+    last_elapsed_days REAL NOT NULL,
+    scheduled_days REAL NOT NULL,
+    rating INTEGER NOT NULL,
+    state INTEGER NOT NULL,
+    CHECK(state >= 0 AND state <= 3),
+    CHECK(rating >= 0 AND rating <= 4)
+  );
+  PRAGMA user_version = 5;
+`;
+
 /** Schema state before migration v3 (has scroll_top, start/end_offset, but no interval) */
 const SCHEMA_V2 = `
   CREATE TABLE article (
@@ -272,91 +357,6 @@ describe('migration v2 — add scroll_top to article and snippet', () => {
     expect(rows[0].scroll_top).toBe(0);
   });
 });
-
-/** Schema state after migration v5 (has deleted column on all item tables) */
-const SCHEMA_V5 = `
-  CREATE TABLE article (
-    id TEXT NOT NULL,
-    reference TEXT NOT NULL UNIQUE,
-    due INTEGER,
-    interval INTEGER NOT NULL,
-    priority INTEGER NOT NULL,
-    fixed_interval_days INTEGER NULL,
-    dismissed INTEGER NOT NULL DEFAULT FALSE,
-    deleted INTEGER NOT NULL DEFAULT FALSE,
-    scroll_top INTEGER NOT NULL DEFAULT 0,
-    CHECK(interval > 0),
-    CHECK(priority >= 10 AND priority <= 50),
-    CHECK(fixed_interval_days > 0),
-    CHECK(dismissed = FALSE OR dismissed = TRUE),
-    CHECK(deleted = FALSE OR deleted = TRUE),
-    CHECK(due IS NOT NULL OR dismissed = TRUE)
-  );
-  CREATE TABLE snippet (
-    id TEXT NOT NULL,
-    reference TEXT NOT NULL UNIQUE,
-    parent TEXT DEFAULT NULL,
-    due INTEGER,
-    interval INTEGER NOT NULL,
-    priority INTEGER NOT NULL,
-    dismissed INTEGER NOT NULL DEFAULT FALSE,
-    deleted INTEGER NOT NULL DEFAULT FALSE,
-    scroll_top INTEGER NOT NULL DEFAULT 0,
-    start_offset INTEGER DEFAULT NULL,
-    end_offset INTEGER DEFAULT NULL,
-    CHECK(interval > 0),
-    CHECK(priority >= 10 AND priority <= 50),
-    CHECK(dismissed = FALSE OR dismissed = TRUE),
-    CHECK(deleted = FALSE OR deleted = TRUE),
-    CHECK(due IS NOT NULL OR dismissed = TRUE)
-  );
-  CREATE TABLE srs_card (
-    id TEXT NOT NULL,
-    reference TEXT NOT NULL UNIQUE,
-    parent TEXT DEFAULT NULL,
-    created_at INTEGER NOT NULL,
-    due INTEGER NOT NULL,
-    dismissed INTEGER NOT NULL DEFAULT FALSE,
-    deleted INTEGER NOT NULL DEFAULT FALSE,
-    last_review INTEGER,
-    stability REAL NOT NULL,
-    difficulty REAL NOT NULL,
-    elapsed_days REAL NOT NULL,
-    scheduled_days REAL NOT NULL,
-    reps INTEGER NOT NULL DEFAULT 0,
-    lapses INTEGER NOT NULL DEFAULT 0,
-    state INTEGER NOT NULL,
-    CHECK(state >= 0 AND state <= 3),
-    CHECK(dismissed = FALSE OR dismissed = TRUE),
-    CHECK(deleted = FALSE OR deleted = TRUE)
-  );
-  CREATE TABLE article_review (
-    id TEXT NOT NULL,
-    article_id TEXT NOT NULL REFERENCES article(id),
-    review_time INTEGER NOT NULL
-  );
-  CREATE TABLE snippet_review (
-    id TEXT NOT NULL,
-    snippet_id TEXT NOT NULL REFERENCES snippet(id),
-    review_time INTEGER NOT NULL
-  );
-  CREATE TABLE srs_card_review (
-    id TEXT NOT NULL,
-    card_id TEXT NOT NULL REFERENCES srs_card(id),
-    due INTEGER NOT NULL,
-    review INTEGER NOT NULL,
-    stability REAL NOT NULL,
-    difficulty REAL NOT NULL,
-    elapsed_days REAL NOT NULL,
-    last_elapsed_days REAL NOT NULL,
-    scheduled_days REAL NOT NULL,
-    rating INTEGER NOT NULL,
-    state INTEGER NOT NULL,
-    CHECK(state >= 0 AND state <= 3),
-    CHECK(rating >= 0 AND rating <= 4)
-  );
-  PRAGMA user_version = 5;
-`;
 
 // ---------------------------------------------------------------------------
 // Migration v3 tests
@@ -726,5 +726,21 @@ describe('migration v6 — vault-relative references', () => {
   it('advances schema version to 6', () => {
     applyMigrations(db, migrations);
     expect(getSchemaVersion(db)).toBe(6);
+  });
+
+  it('leaves non-reference columns unchanged after prefixing', () => {
+    applyMigrations(db, migrations);
+    const articles = selectAll(db, 'article');
+    expect(articles[0].due).toBe(1000);
+    expect(articles[0].interval).toBe(86400000);
+    expect(articles[0].priority).toBe(30);
+    const snippets = Object.fromEntries(selectAll(db, 'snippet').map((r) => [r.id, r]));
+    expect(snippets['s1'].due).toBe(1000);
+    expect(snippets['s1'].interval).toBe(86400000);
+    expect(snippets['s1'].priority).toBe(20);
+    const cards = selectAll(db, 'srs_card');
+    expect(cards[0].due).toBe(1000);
+    expect(cards[0].stability).toBe(1.0);
+    expect(cards[0].difficulty).toBe(1.0);
   });
 });

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,4 +1,4 @@
-import { TEXT_BASE_REVIEW_INTERVAL } from '#/lib/constants';
+import { DATA_DIRECTORY, TEXT_BASE_REVIEW_INTERVAL } from '#/lib/constants';
 import type { TableNameToRowType } from '#/lib/types';
 import type { SafeOmit } from '#/lib/utility-types';
 import {
@@ -296,6 +296,17 @@ export const migrations: Migration[] = [
           state: 'state',
         }
       );
+    },
+  },
+  {
+    version: 6,
+    description: 'Migrate references from DATA_DIRECTORY-relative to vault-relative paths',
+    up: (db) => {
+      db.exec(`UPDATE article SET reference = '${DATA_DIRECTORY}/' || reference WHERE reference NOT LIKE '${DATA_DIRECTORY}/%'`);
+      db.exec(`UPDATE snippet SET reference = '${DATA_DIRECTORY}/' || reference WHERE reference NOT LIKE '${DATA_DIRECTORY}/%'`);
+      db.exec(`UPDATE snippet SET parent = '${DATA_DIRECTORY}/' || parent WHERE parent IS NOT NULL AND parent NOT LIKE '${DATA_DIRECTORY}/%'`);
+      db.exec(`UPDATE srs_card SET reference = '${DATA_DIRECTORY}/' || reference WHERE reference NOT LIKE '${DATA_DIRECTORY}/%'`);
+      db.exec(`UPDATE srs_card SET parent = '${DATA_DIRECTORY}/' || parent WHERE parent IS NOT NULL AND parent NOT LIKE '${DATA_DIRECTORY}/%'`);
     },
   },
 ];

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -97,4 +97,4 @@ CREATE TABLE IF NOT EXISTS srs_card_review (
   CHECK(rating >= 0 AND rating <= 4)
 );
 
-PRAGMA user_version = 5;
+PRAGMA user_version = 6;

--- a/src/lib/Actions.test.ts
+++ b/src/lib/Actions.test.ts
@@ -1,0 +1,344 @@
+import { Actions } from '#/lib/Actions';
+import { CONTENT_TITLE_SLICE_LENGTH } from '#/lib/constants';
+import { store } from '#/lib/store';
+import type { ReviewItem } from '#/lib/types';
+import IncrementalReadingPlugin from '#/main';
+import type { TFile } from 'obsidian';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('#/lib/query-client', () => ({
+  invalidateItemQuery: vi.fn().mockResolvedValue(undefined),
+  invalidateCurrentItemQuery: vi.fn().mockResolvedValue(undefined),
+  fetchCurrentItem: vi.fn().mockResolvedValue(null),
+}));
+
+// #region HELPERS
+
+function makeTFile(basename: string, path?: string): TFile {
+  return {
+    path: path ?? `incremental-reading/articles/${basename}.md`,
+    basename,
+    name: `${basename}.md`,
+    extension: 'md',
+  } as unknown as TFile;
+}
+
+function makePlugin() {
+  return {
+    store: { dispatch: vi.fn() },
+    settings: { dayRolloverOffset: 4 },
+    reviewManager: {
+      dismissItem: vi.fn().mockResolvedValue(undefined),
+      unDismissItem: vi.fn().mockResolvedValue(undefined),
+    },
+    app: {
+      workspace: {
+        activeEditor: null,
+        getActiveViewOfType: vi.fn().mockReturnValue(null),
+      },
+    },
+  } as unknown as IncrementalReadingPlugin;
+}
+
+function makeReviewItem(basename: string, pathOverride?: string): ReviewItem {
+  return {
+    data: {
+      id: 'item-1',
+      type: 'article',
+      reference: pathOverride ?? `incremental-reading/articles/${basename}.md`,
+      due: Date.now(),
+      dismissed: false,
+      deleted: false,
+    },
+    file: makeTFile(basename, pathOverride),
+  } as unknown as ReviewItem;
+}
+
+// #endregion
+
+// ---------------------------------------------------------------------------
+// skipItem — Notice message
+// ---------------------------------------------------------------------------
+
+describe('Actions.skipItem — Notice message', () => {
+  let NoticeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    NoticeMock = vi.fn();
+    vi.stubGlobal('Notice', NoticeMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('Notice contains the file basename', () => {
+    const actions = new Actions(makePlugin());
+    actions.skipItem(makeReviewItem('my-article'));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('my-article');
+  });
+
+  it('Notice contains "until next session"', () => {
+    const actions = new Actions(makePlugin());
+    actions.skipItem(makeReviewItem('my-article'));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('until next session');
+  });
+
+  it('does not leak folder name from multi-segment path into Notice', () => {
+    // Regression: reference.split('/')[1] → folder name ('articles'), not file
+    const item = makeReviewItem('note', 'folder-a/subfolder/note.md');
+    const actions = new Actions(makePlugin());
+    actions.skipItem(item);
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('note');
+    expect(message).not.toContain('folder-a');
+    expect(message).not.toContain('subfolder');
+  });
+
+  it('truncates long basename with ellipsis', () => {
+    const longName = 'a'.repeat(CONTENT_TITLE_SLICE_LENGTH + 20);
+    const actions = new Actions(makePlugin());
+    actions.skipItem(makeReviewItem(longName));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('...');
+  });
+
+  it('does not truncate a name at exactly CONTENT_TITLE_SLICE_LENGTH + 5 characters', () => {
+    // Kills ArithmeticOperator mutant: +5 → -5 (a 55-char name is truncated at 45 but not at 55)
+    const name = 'a'.repeat(CONTENT_TITLE_SLICE_LENGTH + 5);
+    const actions = new Actions(makePlugin());
+    actions.skipItem(makeReviewItem(name));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).not.toContain('...');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dismissItem — Notice message
+// ---------------------------------------------------------------------------
+
+describe('Actions.dismissItem — Notice message', () => {
+  let NoticeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    NoticeMock = vi.fn();
+    vi.stubGlobal('Notice', NoticeMock);
+    vi.spyOn(store, 'getState').mockReturnValue({
+      currentItemId: null,
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('Notice contains the file basename', async () => {
+    const actions = new Actions(makePlugin());
+    await actions.dismissItem(makeReviewItem('my-article'));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('my-article');
+  });
+
+  it('Notice matches Dismissed "..." format', async () => {
+    const actions = new Actions(makePlugin());
+    await actions.dismissItem(makeReviewItem('my-article'));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toMatch(/^Dismissed ".*"$/);
+  });
+
+  it('does not leak folder name from multi-segment path into Notice', async () => {
+    const item = makeReviewItem('note', 'folder-a/subfolder/note.md');
+    const actions = new Actions(makePlugin());
+    await actions.dismissItem(item);
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('note');
+    expect(message).not.toContain('folder-a');
+  });
+
+  it('truncates long basename with ellipsis', async () => {
+    const longName = 'a'.repeat(CONTENT_TITLE_SLICE_LENGTH + 20);
+    const actions = new Actions(makePlugin());
+    await actions.dismissItem(makeReviewItem(longName));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('...');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unDismissItem — Notice message
+// ---------------------------------------------------------------------------
+
+describe('Actions.unDismissItem — Notice message', () => {
+  let NoticeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    NoticeMock = vi.fn();
+    vi.stubGlobal('Notice', NoticeMock);
+    vi.spyOn(store, 'getState').mockReturnValue({
+      currentItemId: null,
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('Notice contains the file basename', async () => {
+    const actions = new Actions(makePlugin());
+    await actions.unDismissItem(makeReviewItem('my-article'));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('my-article');
+  });
+
+  it('Notice contains "to queue"', async () => {
+    const actions = new Actions(makePlugin());
+    await actions.unDismissItem(makeReviewItem('my-article'));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('to queue');
+  });
+
+  it('Notice matches Restored "..." to queue format', async () => {
+    const actions = new Actions(makePlugin());
+    await actions.unDismissItem(makeReviewItem('my-article'));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toMatch(/^Restored ".*" to queue$/);
+  });
+
+  it('does not leak folder name from multi-segment path into Notice', async () => {
+    const item = makeReviewItem('note', 'folder-a/subfolder/note.md');
+    const actions = new Actions(makePlugin());
+    await actions.unDismissItem(item);
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('note');
+    expect(message).not.toContain('folder-a');
+  });
+
+  it('truncates long basename with ellipsis', async () => {
+    const longName = 'a'.repeat(CONTENT_TITLE_SLICE_LENGTH + 20);
+    const actions = new Actions(makePlugin());
+    await actions.unDismissItem(makeReviewItem(longName));
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const [message] = NoticeMock.mock.calls[0] as [string];
+    expect(message).toContain('...');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// skipItem — dispatch
+// ---------------------------------------------------------------------------
+
+describe('Actions.skipItem — dispatch', () => {
+  let NoticeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    NoticeMock = vi.fn();
+    vi.stubGlobal('Notice', NoticeMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('dispatches addSeenId and resets current item (store.dispatch called twice)', () => {
+    const plugin = makePlugin();
+    const actions = new Actions(plugin);
+    actions.skipItem(makeReviewItem('my-article'));
+    // skipItem calls dispatch(addSeenId) directly, then getNext() calls dispatch(resetCurrentItem)
+    expect(plugin.store.dispatch).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dismissItem — dispatch
+// ---------------------------------------------------------------------------
+
+describe('Actions.dismissItem — dispatch', () => {
+  let NoticeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    NoticeMock = vi.fn();
+    vi.stubGlobal('Notice', NoticeMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('calls store.dispatch (getNext) when the dismissed item is the current item', async () => {
+    vi.spyOn(store, 'getState').mockReturnValue({
+      currentItemId: 'item-1',
+    } as never);
+    const plugin = makePlugin();
+    const actions = new Actions(plugin);
+    await actions.dismissItem(makeReviewItem('my-article')); // item id is 'item-1'
+    expect(plugin.store.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call store.dispatch when the dismissed item is not the current item', async () => {
+    vi.spyOn(store, 'getState').mockReturnValue({
+      currentItemId: 'other-item',
+    } as never);
+    const plugin = makePlugin();
+    const actions = new Actions(plugin);
+    await actions.dismissItem(makeReviewItem('my-article')); // item id 'item-1' !== 'other-item'
+    expect(plugin.store.dispatch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unDismissItem — dispatch
+// ---------------------------------------------------------------------------
+
+describe('Actions.unDismissItem — dispatch', () => {
+  let NoticeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    NoticeMock = vi.fn();
+    vi.stubGlobal('Notice', NoticeMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('calls store.dispatch (getNext) when currentItemId is null', async () => {
+    vi.spyOn(store, 'getState').mockReturnValue({
+      currentItemId: null,
+    } as never);
+    const plugin = makePlugin();
+    const actions = new Actions(plugin);
+    await actions.unDismissItem(makeReviewItem('my-article'));
+    expect(plugin.store.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call store.dispatch when currentItemId is not null', async () => {
+    vi.spyOn(store, 'getState').mockReturnValue({
+      currentItemId: 'some-item',
+    } as never);
+    const plugin = makePlugin();
+    const actions = new Actions(plugin);
+    await actions.unDismissItem(makeReviewItem('my-article'));
+    expect(plugin.store.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -140,9 +140,8 @@ export class Actions {
     await this.plugin.reviewManager.dismissItem(item);
     await invalidateItemQuery(item.data.id);
 
-    const [_folder, subRef] = item.data.reference.split('/');
     new Notice(
-      `Dismissed "${getContentSlice(subRef, CONTENT_TITLE_SLICE_LENGTH, true)}"`
+      `Dismissed "${getContentSlice(item.file.basename, CONTENT_TITLE_SLICE_LENGTH, true)}"`
     );
     const { currentItemId } = store.getState();
     if (item.data.id === currentItemId) {
@@ -159,9 +158,8 @@ export class Actions {
       this.getNext();
     }
 
-    const [_folder, subRef] = item.data.reference.split('/');
     new Notice(
-      `Restored "${getContentSlice(subRef, CONTENT_TITLE_SLICE_LENGTH, true)}" to queue`
+      `Restored "${getContentSlice(item.file.basename, CONTENT_TITLE_SLICE_LENGTH, true)}" to queue`
     );
   };
 
@@ -180,10 +178,8 @@ export class Actions {
     const resetTime = getEndOfToday(this.plugin.settings.dayRolloverOffset);
     this.plugin.store.dispatch(addSeenId({ id: item.data.id, resetTime }));
 
-    const { reference } = item.data;
-    const [folder, subRef] = reference.split('/');
     new Notice(
-      `Skipping ${folder}/${getContentSlice(subRef, CONTENT_TITLE_SLICE_LENGTH + 5, true)} until next session`
+      `Skipping ${getContentSlice(item.file.basename, CONTENT_TITLE_SLICE_LENGTH + 5, true)} until next session`
     );
     this.getNext();
   };

--- a/src/lib/ObsidianHelpers.test.ts
+++ b/src/lib/ObsidianHelpers.test.ts
@@ -224,10 +224,8 @@ describe('sanitizeForTitle', () => {
   });
 
   it('checkFinalChar=false preserves trailing space', () => {
-    // trim() is always applied, but trailing space before trim is stripped
-    // The function calls .trim() at the end, so trailing space is removed regardless
     const result = ObsidianHelpers.sanitizeForTitle('hello ', false);
-    expect(result).toBe('hello');
+    expect(result).toBe('hello ');
   });
 
   it('checkFinalChar=false preserves trailing period', () => {
@@ -235,12 +233,15 @@ describe('sanitizeForTitle', () => {
     expect(result).toBe('hello.');
   });
 
-  it('trims whitespace from both ends', () => {
+  it('trims leading whitespace but preserves the trailing character', () => {
     fc.assert(
       fc.property(fc.string(), (text) => {
-        const padded = `   ${text}   `;
+        const padded = `   ${text}`;
         const result = ObsidianHelpers.sanitizeForTitle(padded, false);
-        expect(result).toBe(result.trim());
+        // The last char is always preserved as-is (possibly whitespace).
+        // Everything before it has leading whitespace stripped, so if the result
+        // is longer than 1 char it must start with a non-whitespace character.
+        expect(result.length <= 1 || result === result.trimStart()).toBe(true);
       })
     );
   });
@@ -264,11 +265,11 @@ describe('sanitizeForTitle', () => {
     expect(result.length).toBe(300);
   });
 
-  it('returns empty string for input containing only forbidden chars', () => {
+  it('returns a whitespace-only string for input containing only forbidden chars', () => {
     const input = [...FORBIDDEN_TITLE_CHARS].join('');
     const result = ObsidianHelpers.sanitizeForTitle(input, false);
-    // All forbidden chars become spaces, then trimmed
-    expect(result.trim()).toBe(result);
+    // All forbidden chars become spaces; the last space is preserved as the trailing char
+    expect(result.trim()).toBe('');
     // No forbidden chars remain
     [...FORBIDDEN_TITLE_CHARS].forEach((c) => expect(result).not.toContain(c));
   });
@@ -281,11 +282,14 @@ describe('sanitizeForTitle', () => {
             return false;
           }
           if (s.startsWith('.')) return false;
+          // Leading whitespace is trimmed from all-but-last chars, so strings
+          // longer than 1 with leading whitespace are NOT returned unchanged.
+          if (s.length > 1 && s !== s.trimStart()) return false;
           return true;
         }),
         (text) => {
           const result = ObsidianHelpers.sanitizeForTitle(text, false);
-          expect(result).toBe(text.trim());
+          expect(result).toBe(text);
         }
       )
     );
@@ -652,7 +656,10 @@ describe('getNote', () => {
         getFileByPath: vi.fn().mockReturnValue(file),
       } as unknown as App['vault'],
     });
-    const result = ObsidianHelpers.getNote(`${DATA_DIRECTORY}/articles/note.md`, app);
+    const result = ObsidianHelpers.getNote(
+      `${DATA_DIRECTORY}/articles/note.md`,
+      app
+    );
     expect(app.vault.getFileByPath).toHaveBeenCalledWith(
       `${DATA_DIRECTORY}/articles/note.md`
     );
@@ -661,8 +668,24 @@ describe('getNote', () => {
 
   it('returns null when vault has no matching file', () => {
     const app = makeApp();
-    const result = ObsidianHelpers.getNote(`${DATA_DIRECTORY}/nonexistent.md`, app);
+    const result = ObsidianHelpers.getNote(
+      `${DATA_DIRECTORY}/nonexistent.md`,
+      app
+    );
     expect(result).toBeNull();
+  });
+
+  it('does not strip fragment suffixes from the reference path', () => {
+    const fragmentRef = `${DATA_DIRECTORY}/snippets/snip.md#h1`;
+    const file = makeTFile();
+    const app = makeApp({
+      vault: {
+        getFileByPath: vi.fn().mockReturnValue(file),
+      } as unknown as App['vault'],
+    });
+    const result = ObsidianHelpers.getNote(fragmentRef, app);
+    expect(app.vault.getFileByPath).toHaveBeenCalledWith(fragmentRef);
+    expect(result).toBe(file);
   });
 });
 
@@ -1800,6 +1823,49 @@ describe('smartGetline', () => {
 
     const result = ObsidianHelpers.smartGetline(editor, makeTFile(), app);
     // defaultReturn: start=0, end=line.length, line untouched
+    expect(result.start).toBe(0);
+    expect(result.line).toBe(bulletLine);
+    expect(result.end).toBe(bulletLine.length);
+  });
+
+  it('returns defaultReturn without stripping bullet when cursor is before all list items', () => {
+    // Kills mutant: `if (block.lineNumber < start.line) return -1` → `if (false) return -1`
+    // With the mutant, the binary search comparator never returns -1, so it goes right/matches
+    // the mid-item (returning a truthy match) instead of returning null, causing the bullet
+    // prefix to be stripped incorrectly.
+    const bulletLine = '- item before all list items';
+    const editor = makeEditor({
+      getCursor: vi.fn().mockReturnValue({ line: 0, ch: 0 }),
+      getLine: vi.fn().mockReturnValue(bulletLine),
+    });
+    const listItems = [
+      {
+        position: {
+          start: { line: 5, col: 0, offset: 0 },
+          end: { line: 5, col: 10, offset: 10 },
+        },
+      },
+      {
+        position: {
+          start: { line: 6, col: 0, offset: 0 },
+          end: { line: 6, col: 10, offset: 10 },
+        },
+      },
+      {
+        position: {
+          start: { line: 7, col: 0, offset: 0 },
+          end: { line: 7, col: 10, offset: 10 },
+        },
+      },
+    ];
+    const app = makeApp({
+      metadataCache: {
+        getFileCache: vi.fn().mockReturnValue({ listItems }),
+      } as unknown as App['metadataCache'],
+    });
+
+    const result = ObsidianHelpers.smartGetline(editor, makeTFile(), app);
+    // No match → defaultReturn; bullet prefix must NOT be stripped
     expect(result.start).toBe(0);
     expect(result.line).toBe(bulletLine);
     expect(result.end).toBe(bulletLine.length);

--- a/src/lib/ObsidianHelpers.test.ts
+++ b/src/lib/ObsidianHelpers.test.ts
@@ -361,44 +361,6 @@ describe('createTitle', () => {
 });
 
 // ---------------------------------------------------------------------------
-// getReferenceFromPath
-// ---------------------------------------------------------------------------
-describe('getReferenceFromPath', () => {
-  it('extracts the reference after the DATA_DIRECTORY prefix', () => {
-    const ref = 'articles/note.md';
-    const vaultPath = `${DATA_DIRECTORY}/${ref}`;
-    expect(ObsidianHelpers.getReferenceFromPath(vaultPath)).toBe(ref);
-  });
-
-  it('returns undefined when DATA_DIRECTORY is not in the path', () => {
-    // split on missing separator gives original string at index 0, index 1 is undefined
-    expect(
-      ObsidianHelpers.getReferenceFromPath('other/path/note.md')
-    ).toBeUndefined();
-  });
-
-  it('handles nested paths after DATA_DIRECTORY', () => {
-    const ref = 'snippets/sub/note.md';
-    const vaultPath = `${DATA_DIRECTORY}/${ref}`;
-    expect(ObsidianHelpers.getReferenceFromPath(vaultPath)).toBe(ref);
-  });
-
-  it('returns the reference for arbitrary non-empty subpaths', () => {
-    fc.assert(
-      fc.property(
-        fc
-          .string({ minLength: 1 })
-          .filter((s) => !s.includes(`${DATA_DIRECTORY}/`)),
-        (ref) => {
-          const vaultPath = `${DATA_DIRECTORY}/${ref}`;
-          expect(ObsidianHelpers.getReferenceFromPath(vaultPath)).toBe(ref);
-        }
-      )
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
 // getDirectory
 // ---------------------------------------------------------------------------
 describe('getDirectory', () => {
@@ -683,23 +645,23 @@ describe('getCurrentLine', () => {
 describe('getNote', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('calls getFileByPath with normalized DATA_DIRECTORY/reference path', () => {
+  it('calls getFileByPath with the vault-relative reference path', () => {
     const file = makeTFile();
     const app = makeApp({
       vault: {
         getFileByPath: vi.fn().mockReturnValue(file),
       } as unknown as App['vault'],
     });
-    const result = ObsidianHelpers.getNote('articles/note.md', app);
+    const result = ObsidianHelpers.getNote(`${DATA_DIRECTORY}/articles/note.md`, app);
     expect(app.vault.getFileByPath).toHaveBeenCalledWith(
-      normalizePath(`${DATA_DIRECTORY}/articles/note.md`)
+      `${DATA_DIRECTORY}/articles/note.md`
     );
     expect(result).toBe(file);
   });
 
   it('returns null when vault has no matching file', () => {
     const app = makeApp();
-    const result = ObsidianHelpers.getNote('nonexistent.md', app);
+    const result = ObsidianHelpers.getNote(`${DATA_DIRECTORY}/nonexistent.md`, app);
     expect(result).toBeNull();
   });
 });

--- a/src/lib/ObsidianHelpers.ts
+++ b/src/lib/ObsidianHelpers.ts
@@ -82,10 +82,14 @@ export class ObsidianHelpers {
           return ' ';
         } else return char;
       })
-      .join('')
-      .trim();
+      .join('');
 
-    return maxLength ? cleaned.slice(0, maxLength) : cleaned;
+    const trimmed = checkFinalChar
+      ? cleaned.trim()
+      : cleaned.slice(0, cleaned.length - 1).trimStart() +
+        cleaned.slice(cleaned.length - 1);
+
+    return maxLength ? trimmed.slice(0, maxLength) : trimmed;
   }
 
   /**
@@ -101,7 +105,7 @@ export class ObsidianHelpers {
         false,
         CONTENT_TITLE_SLICE_LENGTH
       );
-      if (sanitized.length > 0) segments.push(sanitized);
+      if (sanitized.trim().length > 0) segments.push(sanitized);
     }
     segments.push(generateId());
     return segments.join(TITLE_SEGMENT_SEPARATOR);

--- a/src/lib/ObsidianHelpers.ts
+++ b/src/lib/ObsidianHelpers.ts
@@ -61,15 +61,6 @@ export class ObsidianHelpers {
     }
   }
 
-  static getReferenceFromPath(vaultPath: string): string {
-    const reference = vaultPath.split(`${DATA_DIRECTORY}/`)[1];
-    return reference;
-  }
-
-  static getPathFromReference(reference: string): string {
-    return normalizePath(`${DATA_DIRECTORY}/${reference}`);
-  }
-
   /**
    * Remove characters that cannot be used for file names
    * or Obsidian note titles
@@ -150,11 +141,9 @@ export class ObsidianHelpers {
     editor.replaceRange(`!${link}`, start, end);
   }
 
-  /** Retrieves notes from the data directory given a row's reference */
+  /** Retrieves a note from the vault given a vault-relative reference */
   static getNote(reference: string, app: App): TFile | null {
-    return app.vault.getFileByPath(
-      normalizePath(`${DATA_DIRECTORY}/${reference}`)
-    );
+    return app.vault.getFileByPath(normalizePath(reference));
   }
 
   /**

--- a/src/lib/extensions/ActionBarExtension.ts
+++ b/src/lib/extensions/ActionBarExtension.ts
@@ -18,7 +18,7 @@ import type IncrementalReadingPlugin from '#/main';
 import { StateEffect, StateField, type Extension } from '@codemirror/state';
 import type { EditorView, Panel } from '@codemirror/view';
 import { showPanel, ViewPlugin } from '@codemirror/view';
-import type { App, TFile } from 'obsidian';
+import type { App, EventRef, TFile } from 'obsidian';
 import { Notice } from 'obsidian';
 import { irPluginFacet } from './irPluginFacet';
 
@@ -476,6 +476,7 @@ function createPriorityInput(
 const noteTypePlugin = ViewPlugin.define((view) => {
   let destroyed = false;
   let lastFilePath: string | undefined;
+  let metadataCacheRef: EventRef | undefined;
 
   const lookup = (filePath: string) => {
     const { info } = Obsidian.getFileInfoFromState(view.state);
@@ -490,21 +491,38 @@ const noteTypePlugin = ViewPlugin.define((view) => {
     lastFilePath = filePath;
   };
 
+  const subscribeToMetadataChanges = (app: App, filePath: string) => {
+    if (metadataCacheRef) {
+      app.metadataCache.offref(metadataCacheRef);
+    }
+    metadataCacheRef = app.metadataCache.on('changed', (changedFile) => {
+      if (changedFile.path === filePath) lookup(filePath);
+    });
+  };
+
   // Initial lookup on mount
   const { info } = Obsidian.getFileInfoFromState(view.state);
-  if (info?.file) lookup(info.file.path);
+  if (info?.file && info.app) {
+    lookup(info.file.path);
+    subscribeToMetadataChanges(info.app, info.file.path);
+  }
 
   return {
     update() {
       const { info: newInfo } = Obsidian.getFileInfoFromState(view.state);
-      if (!newInfo?.file) return;
+      if (!newInfo?.file || !newInfo.app) return;
       // Re-resolve only when the open file actually changes
       if (newInfo.file.path !== lastFilePath) {
         lookup(newInfo.file.path);
+        subscribeToMetadataChanges(newInfo.app, newInfo.file.path);
       }
     },
     destroy() {
       destroyed = true;
+      const { info } = Obsidian.getFileInfoFromState(view.state);
+      if (metadataCacheRef && info?.app) {
+        info.app.metadataCache.offref(metadataCacheRef);
+      }
     },
   };
 });

--- a/src/lib/items/ArticleManager.test.ts
+++ b/src/lib/items/ArticleManager.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable obsidianmd/no-tfile-tfolder-cast -- this is a test file */
 import {
   ARTICLE_DIRECTORY,
+  ARTICLE_TAG,
+  CARD_TAG,
+  DATA_DIRECTORY,
   DAY_ROLLOVER_OFFSET_HOURS,
   DEFAULT_PRIORITY,
   MAXIMUM_FIXED_REVIEW_INTERVAL,
@@ -9,6 +12,7 @@ import {
   MINIMUM_PRIORITY,
   MS_PER_DAY,
   MS_PER_YEAR,
+  SNIPPET_TAG,
   TEXT_BASE_REVIEW_INTERVAL,
 } from '#/lib/constants';
 import IRScheduler from '#/lib/IRScheduler';
@@ -83,6 +87,16 @@ function lastMutateCall(repo: SQLiteRepository): [string, unknown[]] {
     unknown[],
   ][];
   return calls[calls.length - 1];
+}
+
+function makeImportPlugin(copyOnImport: boolean) {
+  return {
+    app: {
+      ...makeApp(),
+      vault: { cachedRead: vi.fn().mockResolvedValue('# Content') },
+    },
+    settings: { copyOnImport, defaultPriority: DEFAULT_PRIORITY },
+  } as never;
 }
 
 /** Returns the [sql, params] tuple from the latest call to repo.query */
@@ -394,7 +408,10 @@ describe('getDue', () => {
       handleFileChange: vi.fn(),
     } as unknown as SQLiteRepository;
 
-    const plugin = { app: makeApp(), settings: { dayRolloverOffset: 0 } } as never;
+    const plugin = {
+      app: makeApp(),
+      settings: { dayRolloverOffset: 0 },
+    } as never;
     const manager = new ArticleManager(plugin, repo);
     await manager.getDue(1);
 
@@ -419,7 +436,10 @@ describe('getDue', () => {
       handleFileChange: vi.fn(),
     } as unknown as SQLiteRepository;
 
-    const plugin = { app: makeApp(), settings: { dayRolloverOffset: 0 } } as never;
+    const plugin = {
+      app: makeApp(),
+      settings: { dayRolloverOffset: 0 },
+    } as never;
     const manager = new ArticleManager(plugin, repo);
     await manager.getDue(0, undefined, [rowA.id]);
 
@@ -461,7 +481,10 @@ describe('getDue', () => {
       handleFileChange: vi.fn(),
     } as unknown as SQLiteRepository;
 
-    const plugin = { app: makeApp(), settings: { dayRolloverOffset: 0 } } as never;
+    const plugin = {
+      app: makeApp(),
+      settings: { dayRolloverOffset: 0 },
+    } as never;
     const manager = new ArticleManager(plugin, repo);
     const results = await manager.getDue(1);
     expect(results.map((r) => r.data.id)).not.toContain('no-file-filter');
@@ -580,10 +603,7 @@ describe('rowToReviewArticle', () => {
     await fc.assert(
       fc.asyncProperty(articleRowArb, async (row) => {
         const repo = makeSimpleRepo();
-        const manager = new ArticleManager(
-          { app: makeApp() } as never,
-          repo
-        );
+        const manager = new ArticleManager({ app: makeApp() } as never, repo);
         const result = manager.rowToReviewArticle(row);
         expect(result).not.toBeNull();
         expect(result!.file).toBe(fakeFile);
@@ -801,10 +821,7 @@ describe('fetch', () => {
       _execSql: vi.fn(),
       handleFileChange: vi.fn(),
     } as unknown as SQLiteRepository;
-    const manager = new ArticleManager(
-      { app: makeApp() } as never,
-      repo
-    );
+    const manager = new ArticleManager({ app: makeApp() } as never, repo);
     const result = await manager.fetch(row.id);
     expect(result).not.toBeNull();
     expect(result!.data.id).toBe(row.id);
@@ -1001,6 +1018,7 @@ describe('rename', () => {
     vi.spyOn(Obsidian, 'renameFile').mockResolvedValue(undefined);
     const newName = 'new-valid-name';
     const extension = 'md';
+    const parentPath = 'some/folder';
     const repo = makeSimpleRepo();
     const manager = new ArticleManager({} as never, repo);
     const article = {
@@ -1008,23 +1026,16 @@ describe('rename', () => {
       file: {
         basename: 'old-name',
         extension,
-        parent: null,
+        path: `${parentPath}/old-name.${extension}`,
+        parent: { path: parentPath },
       } as unknown as TFile,
     };
-
-    // After renameFile is called, the mock's file.basename should reflect the new name;
-    // since the TFile is a plain object, we simulate by mutating it in the spy.
-    (Obsidian.renameFile as ReturnType<typeof vi.spyOn>).mockImplementation(
-      async (file: TFile) => {
-        (file as { basename: string }).basename = newName;
-      }
-    );
 
     await manager.rename(article, newName);
 
     const [sql, params] = lastMutateCall(repo);
     expect(sql).toMatch(/UPDATE article SET reference = \$1 WHERE id = \$2/i);
-    expect(params[0]).toBe(`${ARTICLE_DIRECTORY}/${newName}.${extension}`);
+    expect(params[0]).toBe(`${parentPath}/${newName}.${extension}`);
     expect(params[1]).toBe('art-1');
   });
 
@@ -1240,5 +1251,396 @@ describe('setFixedInterval', () => {
         }
       )
     );
+  });
+});
+
+describe('fetchMany (includeDeleted option)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('omits the deleted filter when includeDeleted=true', async () => {
+    const repo = makeSimpleRepo();
+    const manager = new ArticleManager({} as never, repo);
+    await manager.fetchMany({ includeDeleted: true });
+    const [sql] = lastQueryCall(repo);
+    expect(sql).not.toMatch(/deleted = FALSE/i);
+  });
+
+  it('includes deleted = FALSE filter by default', async () => {
+    const repo = makeSimpleRepo();
+    const manager = new ArticleManager({} as never, repo);
+    await manager.fetchMany();
+    const [sql] = lastQueryCall(repo);
+    expect(sql).toMatch(/deleted = FALSE/i);
+  });
+
+  it('produces no WHERE clause when all filters are disabled', async () => {
+    const repo = makeSimpleRepo();
+    const manager = new ArticleManager({} as never, repo);
+    await manager.fetchMany({ includeDismissed: true, includeDeleted: true });
+    const [sql] = lastQueryCall(repo);
+    expect(sql).not.toContain(' WHERE ');
+  });
+
+  it('throws with a non-empty message when param count exceeds MAX_SQL_QUERY_PARAMS', async () => {
+    const repo = makeSimpleRepo();
+    const manager = new ArticleManager({} as never, repo);
+    const excludeIds = Array.from({ length: 1000 }, (_, i) => `id-${i}`);
+    await expect(manager.fetchMany({ excludeIds })).rejects.toThrow(/exceeded/i);
+  });
+});
+
+describe('rename (no-parent path)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses "<newName>.<ext>" when file has no parent directory', async () => {
+    vi.spyOn(Obsidian, 'renameFile').mockResolvedValue(undefined);
+    const newName = 'rootlevel-name';
+    const extension = 'md';
+    const repo = makeSimpleRepo();
+    const manager = new ArticleManager({} as never, repo);
+    const article = {
+      data: makeArticle({ id: 'art-noparent' }),
+      file: {
+        basename: 'old-name',
+        extension,
+        path: `old-name.${extension}`,
+        parent: null,
+      } as unknown as TFile,
+    };
+
+    await manager.rename(article, newName);
+
+    const [sql, params] = lastMutateCall(repo);
+    expect(sql).toMatch(/UPDATE article SET reference = \$1 WHERE id = \$2/i);
+    expect(params[0]).toBe(`${newName}.${extension}`);
+    expect(params[1]).toBe('art-noparent');
+  });
+});
+
+describe('setFixedInterval (error handling)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw when the validation fails (error is caught)', async () => {
+    const repo = makeSimpleRepo();
+    const manager = new ArticleManager({} as never, repo);
+    await expect(
+      manager.setFixedInterval(makeArticle(), MINIMUM_FIXED_REVIEW_INTERVAL - 1)
+    ).resolves.toBeUndefined();
+    expect(
+      (repo.mutate as ReturnType<typeof vi.fn>).mock.calls
+    ).toHaveLength(0);
+  });
+});
+
+describe('disableFixedInterval (error handling)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw when the validation fails (error is caught internally)', async () => {
+    const repo = makeSimpleRepo();
+    const manager = new ArticleManager({} as never, repo);
+    await expect(
+      manager.disableFixedInterval(makeArticle(), MINIMUM_PRIORITY - 1)
+    ).resolves.toBeUndefined();
+    expect(
+      (repo.mutate as ReturnType<typeof vi.fn>).mock.calls
+    ).toHaveLength(0);
+  });
+});
+
+describe('getDue (filter correctness)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('excludes items where rowToReviewArticle returns null from the final result (article.file null check)', async () => {
+    // rowToReviewArticle returns null when getNote returns null.
+    // Mutant: `!!article && article.file !== null` → `true` would include nulls.
+    // Rows must have distinct references so the mock can discriminate.
+    const rowNoFile = makeArticleRow({ id: 'null-item', reference: 'articles/no-file.md', due: 0 });
+    const rowWithFile = makeArticleRow({ id: 'real-item', reference: 'articles/with-file.md', due: 0 });
+    const file = { path: 'articles/with-file.md' } as TFile;
+
+    vi.spyOn(Obsidian, 'getNote').mockImplementation((ref) =>
+      ref === rowNoFile.reference ? null : file
+    );
+
+    let callCount = 0;
+    const repo = {
+      query: vi.fn().mockImplementation((_sql: string, params: unknown[]) => {
+        callCount++;
+        const excluded = params.slice(1) as string[];
+        return [rowNoFile, rowWithFile].filter(
+          (r) => !excluded.includes(r.id)
+        );
+      }),
+      mutate: vi.fn().mockResolvedValue([[]]),
+      _execSql: vi.fn(),
+      handleFileChange: vi.fn(),
+    } as unknown as SQLiteRepository;
+
+    const plugin = {
+      app: makeApp(),
+      settings: { dayRolloverOffset: 0 },
+    } as never;
+    const manager = new ArticleManager(plugin, repo);
+    const results = await manager.getDue(0);
+
+    expect(results.map((r) => r.data.id)).not.toContain('null-item');
+    expect(results.map((r) => r.data.id)).toContain('real-item');
+    expect(callCount).toBeGreaterThan(1);
+  });
+
+  it('increments the missing-notes counter so the loop retries (not decrements)', async () => {
+    // Mutant: lastMissingNotes += 1 → lastMissingNotes -= 1 would cause the loop
+    // to terminate after one pass even when items are still missing.
+    // Rows must have distinct references so the mock can discriminate.
+    const missingRow = makeArticleRow({ id: 'missing', reference: 'articles/missing.md', due: 0 });
+    const presentRow = makeArticleRow({ id: 'present', reference: 'articles/present.md', due: 0 });
+    const file = { path: 'articles/present.md' } as TFile;
+
+    vi.spyOn(Obsidian, 'getNote').mockImplementation((ref) =>
+      ref === missingRow.reference ? null : file
+    );
+
+    const queryCalls: { sql: string; params: unknown[] }[] = [];
+    const repo = {
+      query: vi.fn().mockImplementation((sql: string, params: unknown[]) => {
+        queryCalls.push({ sql, params });
+        // Extract excludeIds from the params: they follow the optional dueBy param.
+        // Use the SQL to count how many leading params exist before the NOT IN list.
+        const excluded = params.filter(
+          (p): p is string => typeof p === 'string'
+        );
+        return [missingRow, presentRow].filter(
+          (r) => !excluded.includes(r.id)
+        );
+      }),
+      mutate: vi.fn().mockResolvedValue([[]]),
+      _execSql: vi.fn(),
+      handleFileChange: vi.fn(),
+    } as unknown as SQLiteRepository;
+
+    const plugin = {
+      app: makeApp(),
+      settings: { dayRolloverOffset: 0 },
+    } as never;
+    const manager = new ArticleManager(plugin, repo);
+    // Use a future dueBy so the dueBy filter is included (truthy value avoids the bug)
+    await manager.getDue(Date.now() + 1);
+
+    // At least 2 queries should have run — the retry must have happened
+    expect(queryCalls.length).toBeGreaterThanOrEqual(2);
+    // The second call must include the missing row's id as an excluded param
+    expect(queryCalls[1].params).toContain(missingRow.id);
+  });
+});
+
+describe('import', () => {
+  const IMPORT_FILE = {
+    path: 'notes/my-note.md',
+    name: 'my-note.md',
+    basename: 'my-note',
+    extension: 'md',
+  } as TFile;
+
+  const DATA_DIR_FILE = {
+    path: `${DATA_DIRECTORY}/notes/my-note.md`,
+    name: 'my-note.md',
+    basename: 'my-note',
+    extension: 'md',
+  } as TFile;
+
+  const COPY_FILE = {
+    path: `${DATA_DIRECTORY}/${ARTICLE_DIRECTORY}/my-note.md`,
+    name: 'my-note.md',
+    basename: 'my-note',
+    extension: 'md',
+  } as TFile;
+
+  beforeEach(() => {
+    vi.spyOn(Obsidian, 'getFrontMatter').mockReturnValue(undefined);
+    vi.spyOn(Obsidian, 'updateFrontMatter').mockResolvedValue(
+      undefined as never
+    );
+    vi.spyOn(Obsidian, 'isDuplicate').mockReturnValue(false);
+    vi.spyOn(Obsidian, 'createNote').mockResolvedValue(COPY_FILE as never);
+    vi.spyOn(Obsidian, 'generateMarkdownLink').mockReturnValue(
+      '[[notes/my-note.md|my-note]]'
+    );
+    vi.spyOn(Obsidian, 'getDirectory').mockReturnValue(
+      `${DATA_DIRECTORY}/${ARTICLE_DIRECTORY}`
+    );
+    vi.spyOn(Obsidian, 'getTargetPath').mockReturnValue(
+      `${DATA_DIRECTORY}/${ARTICLE_DIRECTORY}/my-note.md`
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('in-place mode', () => {
+    it('registers the original file without creating a copy', async () => {
+      const repo = makeSimpleRepo();
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null, false);
+
+      expect(Obsidian.createNote).not.toHaveBeenCalled();
+      const [sql, params] = lastMutateCall(repo);
+      expect(sql).toContain('INSERT INTO article');
+      expect(params[1]).toBe(IMPORT_FILE.path);
+    });
+
+    it('calls updateFrontMatter on the original file with the article tag', async () => {
+      const repo = makeSimpleRepo();
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null, false);
+
+      expect(Obsidian.updateFrontMatter).toHaveBeenCalledWith(
+        IMPORT_FILE,
+        expect.objectContaining({ tags: ARTICLE_TAG }),
+        expect.anything()
+      );
+    });
+
+    it('does not add a source frontmatter link', async () => {
+      const repo = makeSimpleRepo();
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null, false);
+
+      expect(Obsidian.generateMarkdownLink).not.toHaveBeenCalled();
+      const fmCall = (Obsidian.updateFrontMatter as ReturnType<typeof vi.fn>)
+        .mock.calls[0] as unknown[];
+      expect(fmCall[1]).not.toHaveProperty('source');
+    });
+
+    it('allows files inside DATA_DIRECTORY without early-returning', async () => {
+      const repo = makeSimpleRepo();
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+
+      await manager.import(DATA_DIR_FILE, DEFAULT_PRIORITY, null, false);
+
+      const [sql, params] = lastMutateCall(repo);
+      expect(sql).toContain('INSERT INTO article');
+      expect(params[1]).toBe(DATA_DIR_FILE.path);
+    });
+
+    it('blocks files tagged as snippets', async () => {
+      const repo = makeSimpleRepo();
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+      vi.spyOn(Obsidian, 'getFrontMatter').mockReturnValue({
+        tags: [SNIPPET_TAG],
+      } as never);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null, false);
+
+      expect(repo.mutate).not.toHaveBeenCalled();
+    });
+
+    it('blocks files tagged as cards', async () => {
+      const repo = makeSimpleRepo();
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+      vi.spyOn(Obsidian, 'getFrontMatter').mockReturnValue({
+        tags: [CARD_TAG],
+      } as never);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null, false);
+
+      expect(repo.mutate).not.toHaveBeenCalled();
+    });
+
+    it('re-associates with the existing DB record when ir-id matches', async () => {
+      const EXISTING_ID = 'existing-article-id';
+      const repo = makeSimpleRepo();
+      (repo.query as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        { id: EXISTING_ID },
+      ]);
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+      vi.spyOn(Obsidian, 'getFrontMatter').mockReturnValue({
+        'ir-id': EXISTING_ID,
+      } as never);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null, false);
+
+      const [sql, params] = lastMutateCall(repo);
+      expect(sql).toContain('UPDATE article SET reference');
+      expect(params).toEqual([IMPORT_FILE.path, EXISTING_ID]);
+      expect(Obsidian.updateFrontMatter).not.toHaveBeenCalled();
+    });
+
+    it('cancels with a specific notice when ir-id is orphaned but reference is already in DB', async () => {
+      const ORPHANED_ID = 'orphaned-id';
+      const repo = makeSimpleRepo();
+      // First query (by id) returns nothing; second query (by reference) returns a match
+      (repo.query as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ id: 'some-other-id' }]);
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+      vi.spyOn(Obsidian, 'getFrontMatter').mockReturnValue({
+        'ir-id': ORPHANED_ID,
+      } as never);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null, false);
+
+      expect(repo.mutate).not.toHaveBeenCalled();
+      expect(Obsidian.updateFrontMatter).not.toHaveBeenCalled();
+    });
+
+    it('proceeds with fresh import when ir-id is orphaned and reference is not in DB', async () => {
+      const ORPHANED_ID = 'orphaned-id';
+      const repo = makeSimpleRepo();
+      // Both queries return nothing
+      (repo.query as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+      vi.spyOn(Obsidian, 'getFrontMatter').mockReturnValue({
+        'ir-id': ORPHANED_ID,
+      } as never);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null, false);
+
+      const [sql] = lastMutateCall(repo);
+      expect(sql).toContain('INSERT INTO article');
+    });
+  });
+
+  describe('plugin.settings.copyOnImport fallback', () => {
+    it('uses copy when copyOnImport is true and makeCopy arg is omitted', async () => {
+      const repo = makeSimpleRepo();
+      const manager = new ArticleManager(makeImportPlugin(true), repo);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null);
+
+      expect(Obsidian.createNote).toHaveBeenCalled();
+      const [, params] = lastMutateCall(repo);
+      expect(params[1]).toBe(COPY_FILE.path);
+    });
+
+    it('uses in-place when copyOnImport is false and makeCopy arg is omitted', async () => {
+      const repo = makeSimpleRepo();
+      const manager = new ArticleManager(makeImportPlugin(false), repo);
+
+      await manager.import(IMPORT_FILE, DEFAULT_PRIORITY, null);
+
+      expect(Obsidian.createNote).not.toHaveBeenCalled();
+      const [, params] = lastMutateCall(repo);
+      expect(params[1]).toBe(IMPORT_FILE.path);
+    });
   });
 });

--- a/src/lib/items/ArticleManager.ts
+++ b/src/lib/items/ArticleManager.ts
@@ -1,5 +1,4 @@
 import {
-  ARTICLE_DIRECTORY,
   ARTICLE_TAG,
   CARD_TAG,
   CONTENT_TITLE_SLICE_LENGTH,
@@ -183,7 +182,7 @@ export class ArticleManager extends ItemManager {
         'INSERT INTO article (id, reference, due, interval, priority, fixed_interval_days) VALUES ($1, $2, $3, $4, $5, $6)',
         [
           id,
-          `${ARTICLE_DIRECTORY}/${articleFile.name}`,
+          articleFile.path,
           dueTime,
           TEXT_BASE_REVIEW_INTERVAL,
           priority,
@@ -257,13 +256,7 @@ export class ArticleManager extends ItemManager {
       const dueTime = Date.now();
       await this.repo.mutate(
         'INSERT INTO article (id, reference, due, interval, priority) VALUES ($1, $2, $3, $4, $5)',
-        [
-          id,
-          `${ARTICLE_DIRECTORY}/${articleFile.name}`,
-          dueTime,
-          TEXT_BASE_REVIEW_INTERVAL,
-          priority,
-        ]
+        [id, articleFile.path, dueTime, TEXT_BASE_REVIEW_INTERVAL, priority]
       );
 
       const result = await this.fetch(id);
@@ -439,10 +432,13 @@ export class ArticleManager extends ItemManager {
     const currentName = file.basename;
     try {
       await Obsidian.renameFile(file, newName, this.app);
-      const newReference = `${ARTICLE_DIRECTORY}/${file.basename}.${file.extension}`;
+      const newPath = file.parent
+        ? `${file.parent.path}/${newName}.${file.extension}`
+        : `${newName}.${file.extension}`;
+
       await this.repo.mutate(
         `UPDATE article SET reference = $1 WHERE id = $2`,
-        [newReference, article.data.id]
+        [newPath, article.data.id]
       );
     } catch (error) {
       console.error(error);

--- a/src/lib/items/ArticleManager.ts
+++ b/src/lib/items/ArticleManager.ts
@@ -31,7 +31,7 @@ import type { TFile } from 'obsidian';
 import { Notice } from 'obsidian';
 import { ItemManager } from './ItemManager';
 
-const IMPORT_BLOCKED_TAGS = new Set([SNIPPET_TAG, CARD_TAG]);
+const IMPORT_BLOCKED_TAGS = new Set([ARTICLE_TAG, SNIPPET_TAG, CARD_TAG]);
 
 export class ArticleManager extends ItemManager {
   static rowToBase(articleRow: ArticleRow): IArticleBase {

--- a/src/lib/items/ArticleManager.ts
+++ b/src/lib/items/ArticleManager.ts
@@ -408,7 +408,7 @@ export class ArticleManager extends ItemManager {
             (article): article is ReviewArticle =>
               !!article && article.file !== null
           );
-      } while (lastMissingNotes !== 0);
+      } while (lastMissingNotes > 0);
       return due;
     } catch (error) {
       console.error(error);
@@ -433,7 +433,7 @@ export class ArticleManager extends ItemManager {
     let query = 'SELECT * FROM article';
     const conditions = [];
     const params = [];
-    if (opts?.dueBy) {
+    if (opts?.dueBy !== undefined) {
       params.push(opts.dueBy);
       conditions.push(`due <= $${params.length}`);
     }
@@ -504,7 +504,7 @@ export class ArticleManager extends ItemManager {
     reviewTime?: number,
     nextReviewInterval?: number
   ) {
-    const reviewed = reviewTime || Date.now();
+    const reviewed = reviewTime ?? Date.now();
     const nextInterval =
       nextReviewInterval ?? IRScheduler.nextInterval(article);
     const nextDueTime = reviewed + nextInterval;

--- a/src/lib/items/ArticleManager.ts
+++ b/src/lib/items/ArticleManager.ts
@@ -31,6 +31,8 @@ import type { TFile } from 'obsidian';
 import { Notice } from 'obsidian';
 import { ItemManager } from './ItemManager';
 
+const IMPORT_BLOCKED_TAGS = new Set([SNIPPET_TAG, CARD_TAG]);
+
 export class ArticleManager extends ItemManager {
   static rowToBase(articleRow: ArticleRow): IArticleBase {
     return {
@@ -92,120 +94,20 @@ export class ArticleManager extends ItemManager {
   }
 
   /**
-   * Import the currently opened note as an article
+   * Import the passed note as an article
    */
   async import(
     file: TFile,
     priority: number,
-    fixedIntervalDays: number | null
+    fixedIntervalDays: number | null,
+    makeCopy?: boolean
   ) {
+    const willCopy = makeCopy ?? this.plugin.settings.copyOnImport;
     try {
-      // check if the file is inside the plugin's data directory
-      if (file.path.startsWith(DATA_DIRECTORY)) {
-        new Notice(
-          `Note is already in the plugin data folder; canceling import`,
-          ERROR_NOTICE_DURATION_MS
-        );
-        return;
+      if (willCopy) {
+        return await this.importCopy(file, priority, fixedIntervalDays);
       }
-      // Read the content of the current file
-      const content = await this.app.vault.cachedRead(file);
-      const frontmatter = Obsidian.getFrontMatter(file, this.app);
-      if (frontmatter?.tags) {
-        if (
-          frontmatter.tags.some((tag) =>
-            new Set([SNIPPET_TAG, CARD_TAG]).has(tag)
-          )
-        ) {
-          new Notice(
-            `Note contains a snippet or card tag; canceling import`,
-            ERROR_NOTICE_DURATION_MS
-          );
-          return;
-        }
-      }
-
-      // check if an article with this name already exists
-      if (Obsidian.isDuplicate(file.name, 'article', this.app)) {
-        new Notice(
-          `Warning: article with name already exists "${file.name}"`,
-          0
-        );
-      }
-
-      let importFileName = file.name;
-      while (Obsidian.isDuplicate(importFileName, 'article', this.app)) {
-        importFileName = `${file.basename} - ${generateId()}.${file.extension}`;
-      }
-
-      // Create a copy in the articles directory
-      const articleFile = await Obsidian.createNote({
-        content,
-        frontmatter: {
-          created: new Date().toISOString(),
-        },
-        fileName: importFileName,
-        directory: Obsidian.getDirectory('article'),
-        app: this.app,
-      });
-
-      if (!articleFile) {
-        throw new Error(
-          `Failed to create note ${Obsidian.getTargetPath(importFileName, 'article')}`
-        );
-      }
-
-      const id = crypto.randomUUID();
-
-      // Tag it and create a link to the source if it doesn't exist
-      const frontmatterUpdates: FrontMatterUpdates = {
-        'ir-id': id,
-        tags: ARTICLE_TAG,
-      };
-      if (!frontmatter?.source) {
-        const sourceLink = Obsidian.generateMarkdownLink(
-          file,
-          articleFile,
-          this.app
-        );
-        frontmatterUpdates[`${SOURCE_PROPERTY_NAME}`] = sourceLink;
-      }
-      await Obsidian.updateFrontMatter(
-        articleFile,
-        frontmatterUpdates,
-        this.app
-      );
-
-      // Insert into database with immediate due time
-      const dueTime = Date.now();
-      await this.repo.mutate(
-        'INSERT INTO article (id, reference, due, interval, priority, fixed_interval_days) VALUES ($1, $2, $3, $4, $5, $6)',
-        [
-          id,
-          articleFile.path,
-          dueTime,
-          TEXT_BASE_REVIEW_INTERVAL,
-          priority,
-          fixedIntervalDays,
-        ]
-      );
-
-      const titleSlice = getContentSlice(
-        articleFile.basename,
-        CONTENT_TITLE_SLICE_LENGTH,
-        true
-      );
-
-      const schedulingString =
-        fixedIntervalDays === null
-          ? `priority ${IRScheduler.toDisplayPriority(priority)}`
-          : `fixed interval of ${fixedIntervalDays} days`;
-      new Notice(
-        `Imported "${titleSlice}" with ${schedulingString}`,
-        SUCCESS_NOTICE_DURATION_MS
-      );
-      const result = await this.fetch(id);
-      return result;
+      return await this.importInPlace(file, priority, fixedIntervalDays);
     } catch (error) {
       new Notice(
         `Failed to import article "${file.name}"`,
@@ -214,6 +116,211 @@ export class ArticleManager extends ItemManager {
       console.error(error);
       return null;
     }
+  }
+
+  /**
+   * Import a note directly
+   */
+  private async importInPlace(
+    file: TFile,
+    priority: number,
+    fixedIntervalDays: number | null
+  ) {
+    const frontmatter = Obsidian.getFrontMatter(file, this.app);
+    if (frontmatter?.tags?.some((tag) => IMPORT_BLOCKED_TAGS.has(tag))) {
+      new Notice(
+        `Note contains a snippet or card tag; canceling import`,
+        ERROR_NOTICE_DURATION_MS
+      );
+      return null;
+    }
+
+    // Re-associate if the file already carries an ir-id
+    const existingId = frontmatter?.['ir-id'] as string | undefined;
+    if (existingId) {
+      const rows = await this.repo.query(
+        'SELECT id FROM article WHERE id = $1',
+        [existingId]
+      );
+      if (rows[0]) {
+        await this.repo.mutate(
+          'UPDATE article SET reference = $1 WHERE id = $2',
+          [file.path, existingId]
+        );
+        return this.fetch(existingId);
+      }
+      // Orphaned ir-id: cancel if the file path is already registered
+      const byRef = await this.repo.query(
+        'SELECT id FROM article WHERE reference = $1',
+        [file.path]
+      );
+      if (byRef[0]) {
+        new Notice(
+          `Note is already registered as an article; canceling import`,
+          ERROR_NOTICE_DURATION_MS
+        );
+        return null;
+      }
+      // Orphaned id + no reference match: fall through to fresh import
+    }
+
+    const id = crypto.randomUUID();
+    await Obsidian.updateFrontMatter(
+      file,
+      { 'ir-id': id, tags: ARTICLE_TAG } satisfies FrontMatterUpdates,
+      this.app
+    );
+
+    const dueTime = Date.now();
+    await this.repo.mutate(
+      'INSERT INTO article (id, reference, due, interval, priority, fixed_interval_days) VALUES ($1, $2, $3, $4, $5, $6)',
+      [
+        id,
+        file.path,
+        dueTime,
+        TEXT_BASE_REVIEW_INTERVAL,
+        priority,
+        fixedIntervalDays,
+      ]
+    );
+
+    const titleSlice = getContentSlice(
+      file.basename,
+      CONTENT_TITLE_SLICE_LENGTH,
+      true
+    );
+    const schedulingString =
+      fixedIntervalDays === null
+        ? `priority ${IRScheduler.toDisplayPriority(priority)}`
+        : `fixed interval of ${fixedIntervalDays} days`;
+    new Notice(
+      `Imported "${titleSlice}" with ${schedulingString}`,
+      SUCCESS_NOTICE_DURATION_MS
+    );
+    return this.fetch(id);
+  }
+
+  /**
+   * Copy a note to the data directory, then import the copy
+   */
+  private async importCopy(
+    file: TFile,
+    priority: number,
+    fixedIntervalDays: number | null
+  ) {
+    // check if the file is inside the plugin's data directory
+    if (file.path.startsWith(DATA_DIRECTORY)) {
+      new Notice(
+        `Note is already in the plugin data folder; canceling import`,
+        ERROR_NOTICE_DURATION_MS
+      );
+      return null;
+    }
+    // Read the content of the current file
+    const content = await this.app.vault.cachedRead(file);
+    const frontmatter = Obsidian.getFrontMatter(file, this.app);
+    if (frontmatter?.tags?.some((tag) => IMPORT_BLOCKED_TAGS.has(tag))) {
+      new Notice(
+        `Note contains a snippet or card tag; canceling import`,
+        ERROR_NOTICE_DURATION_MS
+      );
+      return null;
+    }
+
+    // Re-associate if the source already carries an ir-id with a matching DB row
+    const existingId = frontmatter?.['ir-id'] as string | undefined;
+    if (existingId) {
+      const rows = await this.repo.query(
+        'SELECT id FROM article WHERE id = $1',
+        [existingId]
+      );
+      if (rows[0]) {
+        await this.repo.mutate(
+          'UPDATE article SET reference = $1 WHERE id = $2',
+          [file.path, existingId]
+        );
+        return this.fetch(existingId);
+      }
+      // Orphaned ir-id: warn but proceed with creating the copy
+      new Notice(
+        `Warning: source note has article metadata but no matching record; creating copy`,
+        0
+      );
+    }
+
+    // check if an article with this name already exists
+    if (Obsidian.isDuplicate(file.name, 'article', this.app)) {
+      new Notice(`Warning: article with name already exists "${file.name}"`, 0);
+    }
+
+    let importFileName = file.name;
+    while (Obsidian.isDuplicate(importFileName, 'article', this.app)) {
+      importFileName = `${file.basename} - ${generateId()}.${file.extension}`;
+    }
+
+    // Create a copy in the articles directory
+    const articleFile = await Obsidian.createNote({
+      content,
+      frontmatter: {
+        created: new Date().toISOString(),
+      },
+      fileName: importFileName,
+      directory: Obsidian.getDirectory('article'),
+      app: this.app,
+    });
+
+    if (!articleFile) {
+      throw new Error(
+        `Failed to create note ${Obsidian.getTargetPath(importFileName, 'article')}`
+      );
+    }
+
+    const id = crypto.randomUUID();
+
+    // Tag it and create a link to the source if it doesn't exist
+    const frontmatterUpdates: FrontMatterUpdates = {
+      'ir-id': id,
+      tags: ARTICLE_TAG,
+    };
+    if (!frontmatter?.source) {
+      const sourceLink = Obsidian.generateMarkdownLink(
+        file,
+        articleFile,
+        this.app
+      );
+      frontmatterUpdates[`${SOURCE_PROPERTY_NAME}`] = sourceLink;
+    }
+    await Obsidian.updateFrontMatter(articleFile, frontmatterUpdates, this.app);
+
+    // Insert into database with immediate due time
+    const dueTime = Date.now();
+    await this.repo.mutate(
+      'INSERT INTO article (id, reference, due, interval, priority, fixed_interval_days) VALUES ($1, $2, $3, $4, $5, $6)',
+      [
+        id,
+        articleFile.path,
+        dueTime,
+        TEXT_BASE_REVIEW_INTERVAL,
+        priority,
+        fixedIntervalDays,
+      ]
+    );
+
+    const titleSlice = getContentSlice(
+      articleFile.basename,
+      CONTENT_TITLE_SLICE_LENGTH,
+      true
+    );
+
+    const schedulingString =
+      fixedIntervalDays === null
+        ? `priority ${IRScheduler.toDisplayPriority(priority)}`
+        : `fixed interval of ${fixedIntervalDays} days`;
+    new Notice(
+      `Imported "${titleSlice}" with ${schedulingString}`,
+      SUCCESS_NOTICE_DURATION_MS
+    );
+    return this.fetch(id);
   }
 
   /**

--- a/src/lib/items/CardManager.ts
+++ b/src/lib/items/CardManager.ts
@@ -12,7 +12,6 @@ import type { FSRS, FSRSParameters, Grade, StateType } from 'ts-fsrs';
 import { fsrs, generatorParameters, State } from 'ts-fsrs';
 import {
   CARD_ANSWER_REPLACEMENT,
-  CARD_DIRECTORY,
   CARD_TAG,
   CLOZE_DELIMITER_PATTERN,
   CLOZE_DELIMITERS,
@@ -250,8 +249,7 @@ export class CardManager extends ItemManager {
         this.app
       );
 
-      const reference = `${CARD_DIRECTORY}/${cardFile.basename}.md`;
-      const card = new SRSCard(reference);
+      const card = new SRSCard(cardFile.path);
 
       const linkToSource = Obsidian.generateMarkdownLink(
         sourceFile,

--- a/src/lib/items/ItemManager.ts
+++ b/src/lib/items/ItemManager.ts
@@ -8,6 +8,7 @@ import type {
 } from '#/lib/types';
 import type IncrementalReadingPlugin from '#/main';
 import type { App, TAbstractFile, TFile } from 'obsidian';
+import { normalizePath } from 'obsidian';
 import { ObsidianHelpers as Obsidian } from '../ObsidianHelpers';
 import type { SQLiteRepository } from '../types';
 
@@ -25,7 +26,7 @@ export class ItemManager {
   async findSnippet(snippetFile: TAbstractFile): Promise<SnippetRow | null> {
     const results = await this.repo.query(
       'SELECT * FROM snippet WHERE reference = $1',
-      [Obsidian.getReferenceFromPath(snippetFile.path)]
+      [normalizePath(snippetFile.path)]
     );
 
     return (results[0] as SnippetRow) ?? null;
@@ -34,7 +35,7 @@ export class ItemManager {
   async findCard(cardFile: TAbstractFile): Promise<SRSCardRow | null> {
     const results = await this.repo.query(
       'SELECT * FROM srs_card WHERE reference = $1',
-      [Obsidian.getReferenceFromPath(cardFile.path)]
+      [normalizePath(cardFile.path)]
     );
 
     return (results[0] as SRSCardRow) ?? null;
@@ -43,7 +44,7 @@ export class ItemManager {
   async findArticle(articleFile: TAbstractFile): Promise<ArticleRow | null> {
     const results = await this.repo.query(
       'SELECT * FROM article WHERE reference = $1',
-      [Obsidian.getReferenceFromPath(articleFile.path)]
+      [normalizePath(articleFile.path)]
     );
 
     return (results[0] as ArticleRow) ?? null;

--- a/src/lib/items/ReviewManager.test.ts
+++ b/src/lib/items/ReviewManager.test.ts
@@ -816,9 +816,10 @@ describe('ReviewManager.handleExternalRename', () => {
     vi.restoreAllMocks();
   });
 
-  function makeApp(fileExists: boolean, noteType: NoteType | null = 'article') {
+  function makeApp(fileExists: boolean, noteType: NoteType | null = 'article', filePath?: string) {
+    const resolvedPath = filePath ?? `${IR_DIR}/articles/renamed.md`;
     const file = fileExists
-      ? ({ path: `${IR_DIR}/articles/renamed.md` } as TFile)
+      ? ({ path: resolvedPath } as TFile)
       : null;
     const tagMap: Record<NonNullable<NoteType>, string> = {
       article: 'ir-article',
@@ -883,55 +884,64 @@ describe('ReviewManager.handleExternalRename', () => {
     expect(repo.mutate).not.toHaveBeenCalled();
   });
 
-  it('returns early (no mutate) when oldPath is outside DATA_DIRECTORY', async () => {
+  it('updates reference when item moves from external folder into IR directory', async () => {
     const repo = makeRepo();
+    const newPath = `${IR_DIR}/articles/renamed.md`;
+    const oldPath = 'some-other-folder/old.md';
     const app = makeApp(true, 'article');
     const manager = new ReviewManager(makePlugin(app as never), repo);
     manager.app = app as never;
     vi.spyOn(manager.snippets.offsetTracker, 'renameFile').mockReturnValue(
       undefined
     );
-    const abstractFile = {
-      path: `${IR_DIR}/articles/renamed.md`,
-    } as TAbstractFile;
-    await manager.handleExternalRename(
-      abstractFile,
-      'some-other-folder/old.md'
-    );
-    expect(repo.mutate).not.toHaveBeenCalled();
+    const abstractFile = { path: newPath } as TAbstractFile;
+    await manager.handleExternalRename(abstractFile, oldPath);
+    expect(repo.mutate).toHaveBeenCalled();
+    const [sql, params] = (repo.mutate as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, unknown[]];
+    expect(sql).toContain('UPDATE article');
+    expect(params[0]).toBe(newPath);
+    expect(params[1]).toBe(oldPath);
   });
 
-  it('returns early (no mutate) when newPath is outside DATA_DIRECTORY', async () => {
+  it('updates reference when item moves out of IR directory to external folder', async () => {
     const repo = makeRepo();
-    // file path is outside IR dir
-    const file = { path: 'some-other-folder/renamed.md' } as TFile;
-    const appObj = {
-      vault: {
-        getFileByPath: vi.fn().mockReturnValue(file),
-        cachedRead: vi.fn().mockResolvedValue('---\ntags: [ir-article]\n---\n'),
-      },
-      fileManager: {
-        processFrontMatter: vi.fn().mockImplementation(
-          async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
-            cb({ tags: ['ir-article'] });
-          }
-        ),
-      },
-      metadataCache: { getFileCache: vi.fn(), on: vi.fn().mockReturnValue(Symbol()), offref: vi.fn() },
-    };
-    const manager = new ReviewManager(makePlugin(appObj as never), repo);
-    manager.app = appObj as never;
+    const newPath = 'some-other-folder/renamed.md';
+    const oldPath = `${IR_DIR}/articles/old.md`;
+    const app = makeApp(true, 'article', newPath);
+    const manager = new ReviewManager(makePlugin(app as never), repo);
+    manager.app = app as never;
     vi.spyOn(manager.snippets.offsetTracker, 'renameFile').mockReturnValue(
       undefined
     );
-    const abstractFile = {
-      path: 'some-other-folder/renamed.md',
-    } as TAbstractFile;
-    await manager.handleExternalRename(
-      abstractFile,
-      `${IR_DIR}/articles/old.md`
+    const abstractFile = { path: newPath } as TAbstractFile;
+    await manager.handleExternalRename(abstractFile, oldPath);
+    expect(repo.mutate).toHaveBeenCalled();
+    const [sql, params] = (repo.mutate as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, unknown[]];
+    expect(sql).toContain('UPDATE article');
+    expect(params[0]).toBe(newPath);
+    expect(params[1]).toBe(oldPath);
+  });
+
+  it('updates reference when item moves between two non-IR folders', async () => {
+    const repo = makeRepo();
+    const newPath = 'folder-b/new-name.md';
+    const oldPath = 'folder-a/old-name.md';
+    const app = makeApp(true, 'article', newPath);
+    const manager = new ReviewManager(makePlugin(app as never), repo);
+    manager.app = app as never;
+    vi.spyOn(manager.snippets.offsetTracker, 'renameFile').mockReturnValue(
+      undefined
     );
-    expect(repo.mutate).not.toHaveBeenCalled();
+    const abstractFile = { path: newPath } as TAbstractFile;
+    await manager.handleExternalRename(abstractFile, oldPath);
+    expect(repo.mutate).toHaveBeenCalled();
+    const [sql, params] = (repo.mutate as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, unknown[]];
+    expect(sql).toContain('UPDATE article');
+    expect(params[0]).toBe(newPath);
+    expect(params[1]).toBe(oldPath);
   });
 
   it('returns early (no mutate) when old and new reference are identical', async () => {
@@ -1008,8 +1018,8 @@ describe('ReviewManager.handleExternalRename', () => {
         .calls[0] as [string, unknown[]];
       expect(sql).toContain(`UPDATE ${expectedTable}`);
       expect(sql).toContain('SET reference');
-      expect(params[0]).toBe('articles/new-name.md');
-      expect(params[1]).toBe('articles/old-name.md');
+      expect(params[0]).toBe(`${IR_DIR}/articles/new-name.md`);
+      expect(params[1]).toBe(`${IR_DIR}/articles/old-name.md`);
     }
   );
 });
@@ -1050,9 +1060,6 @@ describe('ReviewManager.saveScrollPosition', () => {
             const repo = makeRepo();
             const manager = new ReviewManager(makePlugin(), repo);
             vi.spyOn(Obsidian, 'getNoteType').mockResolvedValue(noteType);
-            vi.spyOn(Obsidian, 'getReferenceFromPath').mockReturnValue(
-              'articles/test.md'
-            );
             await manager.saveScrollPosition(FAKE_FILE, { top, left: 0 });
             const [sql, params] = (repo.mutate as ReturnType<typeof vi.fn>).mock
               .calls[0] as [string, unknown[]];

--- a/src/lib/items/ReviewManager.test.ts
+++ b/src/lib/items/ReviewManager.test.ts
@@ -244,7 +244,11 @@ describe('ReviewManager.getDue', () => {
         // Generate a "current time" between year 2000 and 2100 at day granularity.
         // Using day offsets (not milliseconds) shrinks the search space from ~3 trillion
         // to ~36 500 values, keeping shrinking fast without losing meaningful coverage.
-        fc.integer({ min: 0, max: Math.floor((YEAR_2100_MS - YEAR_2000_MS) / MS_PER_DAY) })
+        fc
+          .integer({
+            min: 0,
+            max: Math.floor((YEAR_2100_MS - YEAR_2000_MS) / MS_PER_DAY),
+          })
           .map((days) => YEAR_2000_MS + days * MS_PER_DAY),
         // Generate a non-empty subset of note types to include
         fc.subarray(['article', 'snippet', 'card'] as const, { minLength: 1 }),
@@ -449,7 +453,17 @@ describe('ReviewManager delegation', () => {
       .spyOn(manager.articles, 'import')
       .mockResolvedValue(undefined as never);
     await manager.importArticle(FAKE_FILE, 30, null);
-    expect(spy).toHaveBeenCalledWith(FAKE_FILE, 30, null);
+    expect(spy).toHaveBeenCalledWith(FAKE_FILE, 30, null, undefined);
+  });
+
+  it('importArticle forwards inPlace to articles.import', async () => {
+    const repo = makeRepo();
+    const manager = new ReviewManager(makePlugin(), repo);
+    const spy = vi
+      .spyOn(manager.articles, 'import')
+      .mockResolvedValue(undefined as never);
+    await manager.importArticle(FAKE_FILE, 30, null, true);
+    expect(spy).toHaveBeenCalledWith(FAKE_FILE, 30, null, true);
   });
 
   it('createEmptyArticle delegates to articles.create', async () => {
@@ -816,11 +830,13 @@ describe('ReviewManager.handleExternalRename', () => {
     vi.restoreAllMocks();
   });
 
-  function makeApp(fileExists: boolean, noteType: NoteType | null = 'article', filePath?: string) {
+  function makeApp(
+    fileExists: boolean,
+    noteType: NoteType | null = 'article',
+    filePath?: string
+  ) {
     const resolvedPath = filePath ?? `${IR_DIR}/articles/renamed.md`;
-    const file = fileExists
-      ? ({ path: resolvedPath } as TFile)
-      : null;
+    const file = fileExists ? ({ path: resolvedPath } as TFile) : null;
     const tagMap: Record<NonNullable<NoteType>, string> = {
       article: 'ir-article',
       snippet: 'ir-text-snippet',
@@ -836,18 +852,22 @@ describe('ReviewManager.handleExternalRename', () => {
         cachedRead: vi.fn().mockResolvedValue(frontmatterContent),
       },
       fileManager: {
-        processFrontMatter: vi.fn().mockImplementation(
-          async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
-            cb(tags !== undefined ? { tags } : {});
-          }
-        ),
+        processFrontMatter: vi
+          .fn()
+          .mockImplementation(
+            async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
+              cb(tags !== undefined ? { tags } : {});
+            }
+          ),
       },
       metadataCache: {
         getFileCache: vi.fn(),
-        on: vi.fn().mockImplementation((_event: string, cb: (f: TFile) => void) => {
-          if (file) cb(file);
-          return Symbol('ref');
-        }),
+        on: vi
+          .fn()
+          .mockImplementation((_event: string, cb: (f: TFile) => void) => {
+            if (file) cb(file);
+            return Symbol('ref');
+          }),
         offref: vi.fn(),
       },
     };
@@ -954,13 +974,19 @@ describe('ReviewManager.handleExternalRename', () => {
         cachedRead: vi.fn().mockResolvedValue('---\ntags: [ir-article]\n---\n'),
       },
       fileManager: {
-        processFrontMatter: vi.fn().mockImplementation(
-          async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
-            cb({ tags: ['ir-article'] });
-          }
-        ),
+        processFrontMatter: vi
+          .fn()
+          .mockImplementation(
+            async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
+              cb({ tags: ['ir-article'] });
+            }
+          ),
       },
-      metadataCache: { getFileCache: vi.fn(), on: vi.fn().mockReturnValue(Symbol()), offref: vi.fn() },
+      metadataCache: {
+        getFileCache: vi.fn(),
+        on: vi.fn().mockReturnValue(Symbol()),
+        offref: vi.fn(),
+      },
     };
     const manager = new ReviewManager(makePlugin(appObj as never), repo);
     manager.app = appObj as never;
@@ -996,16 +1022,27 @@ describe('ReviewManager.handleExternalRename', () => {
       const appObj = {
         vault: {
           getFileByPath: vi.fn().mockReturnValue(file),
-          cachedRead: vi.fn().mockResolvedValue(`---\ntags: [${tagMap[noteType]}]\n---\n`),
+          cachedRead: vi
+            .fn()
+            .mockResolvedValue(`---\ntags: [${tagMap[noteType]}]\n---\n`),
         },
         fileManager: {
-          processFrontMatter: vi.fn().mockImplementation(
-            async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
-              cb({ tags: [tagMap[noteType]] });
-            }
-          ),
+          processFrontMatter: vi
+            .fn()
+            .mockImplementation(
+              async (
+                _f: unknown,
+                cb: (fm: Record<string, unknown>) => void
+              ) => {
+                cb({ tags: [tagMap[noteType]] });
+              }
+            ),
         },
-        metadataCache: { getFileCache: vi.fn(), on: vi.fn().mockReturnValue(Symbol()), offref: vi.fn() },
+        metadataCache: {
+          getFileCache: vi.fn(),
+          on: vi.fn().mockReturnValue(Symbol()),
+          offref: vi.fn(),
+        },
       };
       const manager = new ReviewManager(makePlugin(appObj as never), repo);
       manager.app = appObj as never;
@@ -1292,6 +1329,235 @@ describe('ReviewManager.getReviewItemFromFile card branch', () => {
   });
 });
 
+describe('ReviewManager.handleExternalRename rowId branch', () => {
+  const IR_DIR = DATA_DIRECTORY;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeAppWithIrId(
+    noteType: 'article' | 'snippet' | 'card',
+    irId: string,
+    newPath: string
+  ) {
+    const tagMap: Record<string, string> = {
+      article: 'ir-article',
+      snippet: 'ir-text-snippet',
+      card: 'ir-card',
+    };
+    const file = { path: newPath } as TFile;
+    return {
+      vault: {
+        getFileByPath: vi.fn().mockReturnValue(file),
+        cachedRead: vi
+          .fn()
+          .mockResolvedValue(
+            `---\ntags: [${tagMap[noteType]}]\nir-id: ${irId}\n---\n`
+          ),
+      },
+      fileManager: {
+        processFrontMatter: vi
+          .fn()
+          .mockImplementation(
+            async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
+              cb({ tags: [tagMap[noteType]], 'ir-id': irId });
+            }
+          ),
+      },
+      metadataCache: {
+        getFileCache: vi.fn(),
+        on: vi.fn().mockReturnValue(Symbol()),
+        offref: vi.fn(),
+      },
+    };
+  }
+
+  it('uses WHERE id = $2 (not WHERE reference = $2) when frontmatter has ir-id', async () => {
+    const repo = makeRepo();
+    const irId = 'known-row-id';
+    const newPath = `${IR_DIR}/articles/renamed.md`;
+    const oldPath = `${IR_DIR}/articles/old.md`;
+    const app = makeAppWithIrId('article', irId, newPath);
+    const manager = new ReviewManager(makePlugin(app as never), repo);
+    manager.app = app as never;
+    vi.spyOn(manager.snippets.offsetTracker, 'renameFile').mockReturnValue(
+      undefined
+    );
+
+    await manager.handleExternalRename(
+      { path: newPath } as TAbstractFile,
+      oldPath
+    );
+
+    expect(repo.mutate).toHaveBeenCalled();
+    const [sql, params] = (repo.mutate as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, unknown[]];
+    expect(sql).toContain('WHERE id = $2');
+    expect(sql).not.toContain('WHERE reference = $2');
+    expect(params[0]).toBe(newPath);
+    expect(params[1]).toBe(irId);
+  });
+
+  it.each([
+    ['article', 'article'],
+    ['snippet', 'snippet'],
+    ['card', 'srs_card'],
+  ] as const)(
+    'rowId branch: updates table "%s" by id for note type %s',
+    async (noteType, expectedTable) => {
+      const repo = makeRepo();
+      const irId = `id-for-${noteType}`;
+      const newPath = `${IR_DIR}/articles/new-name.md`;
+      const oldPath = `${IR_DIR}/articles/old-name.md`;
+      const app = makeAppWithIrId(noteType, irId, newPath);
+      const manager = new ReviewManager(makePlugin(app as never), repo);
+      manager.app = app as never;
+      vi.spyOn(manager.snippets.offsetTracker, 'renameFile').mockReturnValue(
+        undefined
+      );
+
+      await manager.handleExternalRename(
+        { path: newPath } as TAbstractFile,
+        oldPath
+      );
+
+      const [sql, params] = (repo.mutate as ReturnType<typeof vi.fn>).mock
+        .calls[0] as [string, unknown[]];
+      expect(sql).toContain(`UPDATE ${expectedTable}`);
+      expect(sql).toContain('WHERE id = $2');
+      expect(params[1]).toBe(irId);
+    }
+  );
+});
+
+describe('ReviewManager.getReviewItemFromFile card vs null distinction', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null for getNoteType=null, NOT a card ReviewItem (card branch not taken)', async () => {
+    // Mutant: `else if (noteType === 'card')` → `else if (true)` would try to
+    // call findCard even when noteType is null, so we verify null is returned
+    // without calling findCard.
+    const repo = makeRepo();
+    const manager = new ReviewManager(makePlugin(), repo);
+    vi.spyOn(Obsidian, 'getNoteType').mockResolvedValue(null);
+    const findCardSpy = vi
+      .spyOn(manager.cards, 'findCard')
+      .mockResolvedValue(makeCardRow() as never);
+    const result = await manager.getReviewItemFromFile(FAKE_FILE);
+    expect(result).toBeNull();
+    expect(findCardSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns a ReviewCard (not null) for noteType=card when card row exists', async () => {
+    // This test distinguishes the card branch from the null fallthrough:
+    // if mutant changes `=== 'card'` to `true`, the test above catches it;
+    // if the mutant makes cards unreachable this test catches it.
+    const repo = makeRepo();
+    const manager = new ReviewManager(makePlugin(), repo);
+    const row = makeCardRow({ id: 'distinct-card-id' });
+    vi.spyOn(Obsidian, 'getNoteType').mockResolvedValue('card');
+    vi.spyOn(manager.cards, 'findCard').mockResolvedValue(row as never);
+    const result = await manager.getReviewItemFromFile(FAKE_FILE);
+    expect(result).not.toBeNull();
+    expect(result!.data.type).toBe('card');
+    expect(result!.data.id).toBe('distinct-card-id');
+  });
+});
+
+describe('ReviewManager.handleExternalRename CARD_TAG condition', () => {
+  const IR_DIR = DATA_DIRECTORY;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses table "article" (not "srs_card") when file is tagged as article but not card', async () => {
+    // Mutant: `frontmatter.tags.includes(CARD_TAG)` → `true` would make all
+    // non-article, non-snippet files route to srs_card. An article-tagged file
+    // would still hit the article branch before reaching the card branch, but a
+    // file with ONLY the article tag verifies the cascade is correct.
+    const repo = makeRepo();
+    const newPath = `${IR_DIR}/articles/new-name.md`;
+    const oldPath = `${IR_DIR}/articles/old-name.md`;
+    const file = { path: newPath } as TFile;
+    const appObj = {
+      vault: {
+        getFileByPath: vi.fn().mockReturnValue(file),
+        cachedRead: vi.fn().mockResolvedValue('---\ntags: [ir-article]\n---\n'),
+      },
+      fileManager: {
+        processFrontMatter: vi
+          .fn()
+          .mockImplementation(
+            async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
+              cb({ tags: ['ir-article'] });
+            }
+          ),
+      },
+      metadataCache: {
+        getFileCache: vi.fn(),
+        on: vi.fn().mockReturnValue(Symbol()),
+        offref: vi.fn(),
+      },
+    };
+    const manager = new ReviewManager(makePlugin(appObj as never), repo);
+    manager.app = appObj as never;
+    vi.spyOn(manager.snippets.offsetTracker, 'renameFile').mockReturnValue(
+      undefined
+    );
+    const abstractFile = { path: newPath } as TAbstractFile;
+    await manager.handleExternalRename(abstractFile, oldPath);
+    const [sql] = (repo.mutate as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      unknown[],
+    ];
+    expect(sql).toContain('UPDATE article');
+    expect(sql).not.toContain('UPDATE srs_card');
+  });
+
+  it('does not mutate when file has IR-formatted tags array but none match any IR tag', async () => {
+    // A file with defined tags but no CARD/SNIPPET/ARTICLE tags — type stays null, no mutate.
+    // If the CARD_TAG mutant is `true`, this file would get treated as a card and mutate.
+    const repo = makeRepo();
+    const newPath = `${IR_DIR}/articles/some.md`;
+    const oldPath = `${IR_DIR}/articles/other.md`;
+    const file = { path: newPath } as TFile;
+    const appObj = {
+      vault: {
+        getFileByPath: vi.fn().mockReturnValue(file),
+        cachedRead: vi
+          .fn()
+          .mockResolvedValue('---\ntags: [some-other-tag]\n---\n'),
+      },
+      fileManager: {
+        processFrontMatter: vi
+          .fn()
+          .mockImplementation(
+            async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
+              cb({ tags: ['some-other-tag'] });
+            }
+          ),
+      },
+      metadataCache: {
+        getFileCache: vi.fn(),
+        on: vi.fn().mockReturnValue(Symbol()),
+        offref: vi.fn(),
+      },
+    };
+    const manager = new ReviewManager(makePlugin(appObj as never), repo);
+    manager.app = appObj as never;
+    vi.spyOn(manager.snippets.offsetTracker, 'renameFile').mockReturnValue(
+      undefined
+    );
+    const abstractFile = { path: newPath } as TAbstractFile;
+    await manager.handleExternalRename(abstractFile, oldPath);
+    expect(repo.mutate).not.toHaveBeenCalled();
+  });
+});
+
 describe('ReviewManager.handleExternalRename console.warn mutant', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -1307,13 +1573,19 @@ describe('ReviewManager.handleExternalRename console.warn mutant', () => {
         cachedRead: vi.fn().mockResolvedValue('---\ntags: [ir-article]\n---\n'),
       },
       fileManager: {
-        processFrontMatter: vi.fn().mockImplementation(
-          async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
-            cb({ tags: ['ir-article'] });
-          }
-        ),
+        processFrontMatter: vi
+          .fn()
+          .mockImplementation(
+            async (_f: unknown, cb: (fm: Record<string, unknown>) => void) => {
+              cb({ tags: ['ir-article'] });
+            }
+          ),
       },
-      metadataCache: { getFileCache: vi.fn(), on: vi.fn().mockReturnValue(Symbol()), offref: vi.fn() },
+      metadataCache: {
+        getFileCache: vi.fn(),
+        on: vi.fn().mockReturnValue(Symbol()),
+        offref: vi.fn(),
+      },
     };
     const manager = new ReviewManager(makePlugin(appObj as never), repo);
     manager.app = appObj as never;

--- a/src/lib/items/ReviewManager.ts
+++ b/src/lib/items/ReviewManager.ts
@@ -15,14 +15,14 @@ import { getItemType, isArticle } from '#/lib/types';
 import type IncrementalReadingPlugin from '#/main';
 import type ReviewView from '#/views/ReviewView';
 import type { TAbstractFile, TFile } from 'obsidian';
-import { type App, type Editor, type MarkdownView } from 'obsidian';
-import type { Grade } from 'ts-fsrs';
 import {
-  ARTICLE_TAG,
-  CARD_TAG,
-  DATA_DIRECTORY,
-  SNIPPET_TAG,
-} from '../constants';
+  type App,
+  type Editor,
+  type MarkdownView,
+  normalizePath,
+} from 'obsidian';
+import type { Grade } from 'ts-fsrs';
+import { ARTICLE_TAG, CARD_TAG, SNIPPET_TAG } from '../constants';
 import { ObsidianHelpers as Obsidian } from '../ObsidianHelpers';
 import type { SQLiteRepository } from '../types';
 import { compareDates } from '../utils';
@@ -306,14 +306,12 @@ export default class ReviewManager {
    * @param oldPath The vault-relative path the file had before it was moved
    */
   async handleExternalRename(file: TAbstractFile, oldPath: string) {
-    // TODO: handle files being moved into or out of the IR folder
     const newPath = file.path;
     // console.log(`file rename detected: ${oldPath} -> ${newPath}`);
     const concreteFile = this.app.vault.getFileByPath(newPath);
     if (!concreteFile) {
       throw new Error(`Failed to find a file at ${newPath}`);
     }
-    this.snippets.offsetTracker.renameFile(oldPath, newPath);
 
     let type: string | null = null,
       rowId: string | undefined;
@@ -331,16 +329,9 @@ export default class ReviewManager {
       // console.log(`Found no matching IR tags; ignoring`);
       return;
     }
-    if (!oldPath.startsWith(DATA_DIRECTORY)) {
-      // console.log('File was not previously in IR directory; ignoring');
-      return;
-    }
-    if (!newPath.startsWith(DATA_DIRECTORY)) {
-      // console.log('File is no longer in IR directory; ignoring');
-      return;
-    }
 
-    const newReference = Obsidian.getReferenceFromPath(newPath);
+    const newReference = normalizePath(newPath);
+    this.snippets.offsetTracker.renameFile(oldPath, newReference);
     const table = type === 'card' ? 'srs_card' : type;
 
     if (rowId) {
@@ -349,7 +340,7 @@ export default class ReviewManager {
         [newReference, rowId]
       );
     } else {
-      const oldReference = Obsidian.getReferenceFromPath(oldPath);
+      const oldReference = normalizePath(oldPath);
       if (oldReference === newReference) {
         console.warn('File reference did not change; ignoring');
         return;
@@ -375,14 +366,14 @@ export default class ReviewManager {
       const parent = (row as SnippetRow).parent;
       if (parent) {
         this.snippets.offsetTracker.removeHighlight(
-          Obsidian.getPathFromReference(parent),
+          normalizePath(parent),
           row.id
         );
       }
     }
     await this.#repo.mutate(
       `UPDATE ${table} SET deleted = TRUE WHERE reference = $1`,
-      [Obsidian.getReferenceFromPath(file.path)]
+      [normalizePath(file.path)]
     );
   }
 
@@ -411,7 +402,7 @@ export default class ReviewManager {
     const table = type === 'card' ? 'srs_card' : type;
     await this.#repo.mutate(
       `UPDATE ${table} SET deleted = FALSE, reference = $1 WHERE id = $2`,
-      [Obsidian.getReferenceFromPath(file.path), id]
+      [normalizePath(file.path), id]
     );
   }
   /**
@@ -424,7 +415,7 @@ export default class ReviewManager {
     const noteType = await Obsidian.getNoteType(file, this.app);
     if (!noteType || noteType === 'card') return;
 
-    const reference = Obsidian.getReferenceFromPath(file.path);
+    const reference = normalizePath(file.path);
 
     await this.#repo.mutate(
       `UPDATE ${noteType} SET scroll_top = $1 WHERE reference = $2`,

--- a/src/lib/items/ReviewManager.ts
+++ b/src/lib/items/ReviewManager.ts
@@ -330,25 +330,23 @@ export default class ReviewManager {
       return;
     }
 
-    const newReference = normalizePath(newPath);
-    this.snippets.offsetTracker.renameFile(oldPath, newReference);
+    this.snippets.offsetTracker.renameFile(oldPath, file.path);
     const table = type === 'card' ? 'srs_card' : type;
 
     if (rowId) {
       await this.#repo.mutate(
         `UPDATE ${table} SET reference = $1 WHERE id = $2`,
-        [newReference, rowId]
+        [file.path, rowId]
       );
     } else {
-      const oldReference = normalizePath(oldPath);
-      if (oldReference === newReference) {
+      if (oldPath === file.path) {
         console.warn('File reference did not change; ignoring');
         return;
       }
 
       await this.#repo.mutate(
         `UPDATE ${table} SET reference = $1 WHERE reference = $2`,
-        [newReference, oldReference]
+        [file.path, oldPath]
       );
     }
     // console.log(`Reference updated to ${newReference}`);
@@ -373,7 +371,7 @@ export default class ReviewManager {
     }
     await this.#repo.mutate(
       `UPDATE ${table} SET deleted = TRUE WHERE reference = $1`,
-      [normalizePath(file.path)]
+      [file.path]
     );
   }
 
@@ -402,7 +400,7 @@ export default class ReviewManager {
     const table = type === 'card' ? 'srs_card' : type;
     await this.#repo.mutate(
       `UPDATE ${table} SET deleted = FALSE, reference = $1 WHERE id = $2`,
-      [normalizePath(file.path), id]
+      [file.path, id]
     );
   }
   /**
@@ -415,11 +413,9 @@ export default class ReviewManager {
     const noteType = await Obsidian.getNoteType(file, this.app);
     if (!noteType || noteType === 'card') return;
 
-    const reference = normalizePath(file.path);
-
     await this.#repo.mutate(
       `UPDATE ${noteType} SET scroll_top = $1 WHERE reference = $2`,
-      [Math.round(scrollInfo.top), reference]
+      [Math.round(scrollInfo.top), file.path]
     );
   }
 

--- a/src/lib/items/ReviewManager.ts
+++ b/src/lib/items/ReviewManager.ts
@@ -1,3 +1,4 @@
+import { ARTICLE_TAG, CARD_TAG, SNIPPET_TAG } from '#/lib/constants';
 import type {
   ArticleRow,
   IArticleBase,
@@ -22,7 +23,6 @@ import {
   normalizePath,
 } from 'obsidian';
 import type { Grade } from 'ts-fsrs';
-import { ARTICLE_TAG, CARD_TAG, SNIPPET_TAG } from '../constants';
 import { ObsidianHelpers as Obsidian } from '../ObsidianHelpers';
 import type { SQLiteRepository } from '../types';
 import { compareDates } from '../utils';
@@ -124,9 +124,10 @@ export default class ReviewManager {
   async importArticle(
     file: TFile,
     priority: number,
-    fixedIntervalDays: number | null
+    fixedIntervalDays: number | null,
+    makeCopy?: boolean
   ) {
-    return this.articles.import(file, priority, fixedIntervalDays);
+    return this.articles.import(file, priority, fixedIntervalDays, makeCopy);
   }
 
   async createEmptyArticle(priority: number) {

--- a/src/lib/items/SnippetManager.ts
+++ b/src/lib/items/SnippetManager.ts
@@ -3,7 +3,6 @@ import {
   ERROR_NOTICE_DURATION_MS,
   MAX_SQL_QUERY_PARAMS,
   REVIEW_COUNT_FOR_PRIORITY_SCALING,
-  SNIPPET_DIRECTORY,
   SNIPPET_TAG,
   SOURCE_PROPERTY_NAME,
   SOURCE_TAG,
@@ -29,7 +28,13 @@ import type {
 import { getEndOfToday } from '#/lib/utils';
 import type IncrementalReadingPlugin from '#/main';
 import type ReviewView from '#/views/ReviewView';
-import { Notice, TFile, normalizePath, type Editor, type MarkdownView } from 'obsidian';
+import {
+  normalizePath,
+  Notice,
+  TFile,
+  type Editor,
+  type MarkdownView,
+} from 'obsidian';
 import { refreshHighlightsEffect } from '../extensions';
 import { ArticleManager } from './ArticleManager';
 import { ItemManager } from './ItemManager';
@@ -342,7 +347,7 @@ export class SnippetManager extends ItemManager {
       // save the snippet to the database
       await this.repo.mutate(query, [
         id,
-        `${SNIPPET_DIRECTORY}/${snippetFile.name}`,
+        snippetFile.path,
         dueTime,
         TEXT_BASE_REVIEW_INTERVAL,
         priority,

--- a/src/lib/items/SnippetManager.ts
+++ b/src/lib/items/SnippetManager.ts
@@ -29,7 +29,7 @@ import type {
 import { getEndOfToday } from '#/lib/utils';
 import type IncrementalReadingPlugin from '#/main';
 import type ReviewView from '#/views/ReviewView';
-import { Notice, TFile, type Editor, type MarkdownView } from 'obsidian';
+import { Notice, TFile, normalizePath, type Editor, type MarkdownView } from 'obsidian';
 import { refreshHighlightsEffect } from '../extensions';
 import { ArticleManager } from './ArticleManager';
 import { ItemManager } from './ItemManager';
@@ -76,7 +76,7 @@ export class SnippetManager extends ItemManager {
         void this.markDeleted(row.id, 'snippet');
       }
       if (row.parent) {
-        const parentPath = Obsidian.getPathFromReference(row.parent);
+        const parentPath = normalizePath(row.parent);
         this.offsetTracker.removeHighlight(parentPath, row.id);
       }
       return null;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -15,6 +15,8 @@ export interface IRPluginSettings {
   reviewOnImport: boolean;
   copyOnImport: boolean;
   dayRolloverOffset: number;
+  showAdvancedImportCommands: boolean;
+  showAdvancedImportMenuItems: boolean;
 }
 export const DEFAULT_SETTINGS: IRPluginSettings = {
   defaultPriority: DEFAULT_PRIORITY,
@@ -22,6 +24,8 @@ export const DEFAULT_SETTINGS: IRPluginSettings = {
   reviewOnImport: true,
   copyOnImport: false,
   dayRolloverOffset: DAY_ROLLOVER_OFFSET_HOURS.DEFAULT,
+  showAdvancedImportCommands: false,
+  showAdvancedImportMenuItems: false,
 };
 
 export class IRSettingTab extends PluginSettingTab {
@@ -110,6 +114,36 @@ export class IRSettingTab extends PluginSettingTab {
           .setDynamicTooltip()
           .onChange(async (value) => {
             this.plugin.settings.dayRolloverOffset = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    new Setting(containerEl).setName('Advanced').setHeading();
+
+    new Setting(containerEl)
+      .setName('Enable extra import hotkeys')
+      .setDesc(
+        `Shortcuts to open or bypass the import modal, import a copy, or import in-place.`
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.showAdvancedImportCommands)
+          .onChange(async (value) => {
+            this.plugin.settings.showAdvancedImportCommands = value;
+            await this.plugin.saveSettings();
+            // TODO: add or remove commands here
+            this.plugin.toggleAdvancedCommands(value);
+          });
+      });
+
+    new Setting(containerEl)
+      .setName('Show extra file menu entries for importing')
+      .setDesc(`Adds entries corresponding to the extra import commands above.`)
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.showAdvancedImportMenuItems)
+          .onChange(async (value) => {
+            this.plugin.settings.showAdvancedImportMenuItems = value;
             await this.plugin.saveSettings();
           });
       });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,6 +1,7 @@
 import type IncrementalReadingPlugin from '#/main';
 import { PluginSettingTab, Setting, type App } from 'obsidian';
 import {
+  DATA_DIRECTORY,
   DAY_ROLLOVER_OFFSET_HOURS,
   DEFAULT_PRIORITY,
   MAXIMUM_PRIORITY,
@@ -12,12 +13,14 @@ export interface IRPluginSettings {
   defaultPriority: number;
   showImportDialog: boolean;
   reviewOnImport: boolean;
+  copyOnImport: boolean;
   dayRolloverOffset: number;
 }
 export const DEFAULT_SETTINGS: IRPluginSettings = {
   defaultPriority: DEFAULT_PRIORITY,
   showImportDialog: true,
   reviewOnImport: true,
+  copyOnImport: false,
   dayRolloverOffset: DAY_ROLLOVER_OFFSET_HOURS.DEFAULT,
 };
 
@@ -72,6 +75,22 @@ export class IRSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.reviewOnImport)
           .onChange(async (value) => {
             this.plugin.settings.reviewOnImport = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    new Setting(containerEl)
+      .setName('Copy articles when importing')
+      .setDesc(
+        `Copy notes into the data directory (${DATA_DIRECTORY}/) when importing` +
+          ' and leave the original note untouched' +
+          ' Disable to import notes in-place.'
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.copyOnImport)
+          .onChange(async (value) => {
+            this.plugin.settings.copyOnImport = value;
             await this.plugin.saveSettings();
           });
       });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -54,10 +54,7 @@ export class IRSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('Show article import dialog')
-      .setDesc(
-        'If enabled, shows a confirmation dialog when importing that allows' +
-          ' article settings to be customized.'
-      )
+      .setDesc('Show a dialog when importing that allows customization.')
       .addToggle((toggle) => {
         toggle
           .setValue(this.plugin.settings.showImportDialog)
@@ -83,7 +80,7 @@ export class IRSettingTab extends PluginSettingTab {
       .setName('Copy articles when importing')
       .setDesc(
         `Copy notes into the data directory (${DATA_DIRECTORY}/) when importing` +
-          ' and leave the original note untouched' +
+          ' and leave the original note untouched.' +
           ' Disable to import notes in-place.'
       )
       .addToggle((toggle) => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -21,7 +21,7 @@ export interface IRPluginSettings {
 export const DEFAULT_SETTINGS: IRPluginSettings = {
   defaultPriority: DEFAULT_PRIORITY,
   showImportDialog: true,
-  reviewOnImport: true,
+  reviewOnImport: false,
   copyOnImport: false,
   dayRolloverOffset: DAY_ROLLOVER_OFFSET_HOURS.DEFAULT,
   showAdvancedImportCommands: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,30 +107,6 @@ export default class IncrementalReadingPlugin extends Plugin {
       },
     });
 
-    const importArticle = async (
-      file: TFile,
-      opts?: {
-        showImportDialog?: boolean;
-        copyOnImport?: boolean;
-        reviewOnImport?: boolean;
-      }
-    ) => {
-      const merged = { ...this.settings, ...(opts ?? {}) };
-      if (merged.showImportDialog) {
-        new ImportModal(this, file, merged.copyOnImport).open();
-      } else {
-        const article = await this.reviewManager.importArticle(
-          file,
-          this.settings.defaultPriority,
-          null,
-          merged.copyOnImport
-        );
-        if (article && merged.reviewOnImport) {
-          await this.learn(article);
-        }
-      }
-    };
-
     this.addCommand({
       id: 'import-article',
       name: 'Import article',
@@ -144,7 +120,7 @@ export default class IncrementalReadingPlugin extends Plugin {
         if (!fileView?.file) return false;
 
         if (checking) return true;
-        void importArticle(fileView.file);
+        void this.importArticle(fileView.file);
       },
     });
 
@@ -167,6 +143,10 @@ export default class IncrementalReadingPlugin extends Plugin {
       callback: async () => await this.learn(),
     });
 
+    if (this.settings.showAdvancedImportCommands) {
+      this.toggleAdvancedCommands(true);
+    }
+
     this.addCommand({
       // TODO: remove after done testing
       id: 'list-entries',
@@ -186,12 +166,58 @@ export default class IncrementalReadingPlugin extends Plugin {
       this.app.workspace.on('file-menu', (menu, abstractFile) => {
         const file = this.app.vault.getFileByPath(abstractFile.path);
         if (file && this.reviewManager) {
+          menu.addSections(['incremental-reading']);
           menu.addItem((item) => {
             item
               .setTitle('Import article')
               .setIcon(PLACEHOLDER_PLUGIN_ICON)
+              .setSection('incremental-reading')
               .onClick(async () => {
-                await importArticle(file);
+                await this.importArticle(file);
+              });
+          });
+
+          if (!this.settings.showAdvancedImportMenuItems) {
+            return;
+          }
+
+          menu.addItem((item) => {
+            item
+              .setTitle('Import a copy')
+              .setIcon(PLACEHOLDER_PLUGIN_ICON)
+              .setSection('incremental-reading')
+              .onClick(async () => {
+                void this.importArticle(file, { copyOnImport: true });
+              });
+          });
+
+          menu.addItem((item) => {
+            item
+              .setTitle('Import in place')
+              .setIcon(PLACEHOLDER_PLUGIN_ICON)
+              .setSection('incremental-reading')
+              .onClick(async () => {
+                void this.importArticle(file, { copyOnImport: false });
+              });
+          });
+
+          menu.addItem((item) => {
+            item
+              .setTitle('Open import dialog...')
+              .setIcon(PLACEHOLDER_PLUGIN_ICON)
+              .setSection('incremental-reading')
+              .onClick(async () => {
+                void this.importArticle(file, { showImportDialog: true });
+              });
+          });
+
+          menu.addItem((item) => {
+            item
+              .setTitle('Quick import')
+              .setIcon(PLACEHOLDER_PLUGIN_ICON)
+              .setSection('incremental-reading')
+              .onClick(async () => {
+                void this.importArticle(file, { showImportDialog: false });
               });
           });
         } else {
@@ -387,6 +413,107 @@ export default class IncrementalReadingPlugin extends Plugin {
     }
 
     await this.app.workspace.revealLeaf(leaf);
+  }
+
+  async importArticle(
+    file: TFile,
+    opts?: {
+      showImportDialog?: boolean;
+      copyOnImport?: boolean;
+      reviewOnImport?: boolean;
+    }
+  ) {
+    const merged = { ...this.settings, ...(opts ?? {}) };
+    if (merged.showImportDialog) {
+      new ImportModal(this, file, merged.copyOnImport).open();
+    } else {
+      const article = await this.reviewManager.importArticle(
+        file,
+        this.settings.defaultPriority,
+        null,
+        merged.copyOnImport
+      );
+      if (article && merged.reviewOnImport) {
+        await this.learn(article);
+      }
+    }
+  }
+
+  toggleAdvancedCommands(enable: boolean) {
+    if (enable) {
+      this.addCommand({
+        id: 'import-article-copy',
+        name: 'Import article as copy',
+        checkCallback: (checking: boolean) => {
+          if (!this.reviewManager) return false;
+
+          const activeReviewView = this.getActiveReviewView();
+          if (activeReviewView) return false;
+
+          const fileView = this.app.workspace.getActiveFileView();
+          if (!fileView?.file) return false;
+
+          if (checking) return true;
+          void this.importArticle(fileView.file, { copyOnImport: true });
+        },
+      });
+
+      this.addCommand({
+        id: 'import-article-in-place',
+        name: 'Import article in place',
+        checkCallback: (checking: boolean) => {
+          if (!this.reviewManager) return false;
+
+          const activeReviewView = this.getActiveReviewView();
+          if (activeReviewView) return false;
+
+          const fileView = this.app.workspace.getActiveFileView();
+          if (!fileView?.file) return false;
+
+          if (checking) return true;
+          void this.importArticle(fileView.file, { copyOnImport: false });
+        },
+      });
+
+      this.addCommand({
+        id: 'open-import-dialog',
+        name: 'Open import dialog...',
+        checkCallback: (checking: boolean) => {
+          if (!this.reviewManager) return false;
+
+          const activeReviewView = this.getActiveReviewView();
+          if (activeReviewView) return false;
+
+          const fileView = this.app.workspace.getActiveFileView();
+          if (!fileView?.file) return false;
+
+          if (checking) return true;
+          void this.importArticle(fileView.file, { showImportDialog: true });
+        },
+      });
+
+      this.addCommand({
+        id: 'quick-import',
+        name: 'Quick import',
+        checkCallback: (checking: boolean) => {
+          if (!this.reviewManager) return false;
+
+          const activeReviewView = this.getActiveReviewView();
+          if (activeReviewView) return false;
+
+          const fileView = this.app.workspace.getActiveFileView();
+          if (!fileView?.file) return false;
+
+          if (checking) return true;
+          void this.importArticle(fileView.file, { showImportDialog: false });
+        },
+      });
+    } else {
+      this.removeCommand('import-article-copy');
+      this.removeCommand('import-article-in-place');
+      this.removeCommand('open-import-dialog');
+      this.removeCommand('quick-import');
+    }
   }
 
   private configureNavbarPosition() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,8 +25,8 @@ import type { IRPluginSettings } from './lib/settings';
 import { DEFAULT_SETTINGS, IRSettingTab } from './lib/settings';
 import { setCurrentItemId, store } from './lib/store';
 import type { ReviewItem, SQLiteRepository } from './lib/types';
+import { ImportModal } from './views/ImportModal';
 import ReviewView from './views/ReviewView';
-import { SchedulingModal } from './views/SchedulingModal';
 
 export default class IncrementalReadingPlugin extends Plugin {
   settings!: IRPluginSettings;
@@ -107,17 +107,25 @@ export default class IncrementalReadingPlugin extends Plugin {
       },
     });
 
-    const importArticle = async (file: TFile) => {
-      if (this.settings.showImportDialog) {
-        new SchedulingModal(this, { file, data: null }).open();
+    const importArticle = async (
+      file: TFile,
+      opts?: {
+        showImportDialog?: boolean;
+        copyOnImport?: boolean;
+        reviewOnImport?: boolean;
+      }
+    ) => {
+      const merged = { ...this.settings, ...(opts ?? {}) };
+      if (merged.showImportDialog) {
+        new ImportModal(this, file, merged.copyOnImport).open();
       } else {
         const article = await this.reviewManager.importArticle(
           file,
           this.settings.defaultPriority,
-          null
+          null,
+          merged.copyOnImport
         );
-        if (article && this.settings.reviewOnImport) {
-          console.log('opening new import for review');
+        if (article && merged.reviewOnImport) {
           await this.learn(article);
         }
       }

--- a/src/views/ImportModal.tsx
+++ b/src/views/ImportModal.tsx
@@ -1,0 +1,76 @@
+import { ImportModalContent } from '#/components/ImportModalContent';
+import type { SchedulingStrategy } from '#/lib/types';
+import type IncrementalReadingPlugin from '#/main';
+import type { TFile } from 'obsidian';
+import { Modal } from 'obsidian';
+import { render } from 'preact';
+
+export class ImportModal extends Modal {
+  plugin: IncrementalReadingPlugin;
+  file: TFile;
+  defaultCopyOnImport: boolean | undefined;
+
+  constructor(
+    plugin: IncrementalReadingPlugin,
+    file: TFile,
+    defaultCopyOnImport?: boolean
+  ) {
+    super(plugin.app);
+    this.plugin = plugin;
+    this.file = file;
+    this.defaultCopyOnImport = defaultCopyOnImport;
+  }
+
+  async handleClose(
+    strategy: SchedulingStrategy,
+    value: number,
+    makeCopy: boolean
+  ) {
+    const { plugin, file } = this;
+    const props: [priority: number, intervalDays: number | null] =
+      strategy === 'priority'
+        ? [value, null]
+        : [plugin.settings.defaultPriority, value];
+    const importedArticle = await plugin.reviewManager.importArticle(
+      file,
+      ...props,
+      makeCopy
+    );
+    if (importedArticle && plugin.settings.reviewOnImport) {
+      await plugin.learn(importedArticle);
+    }
+  }
+
+  onOpen() {
+    const { plugin, contentEl } = this;
+    const schedule = {
+      intervalDays: null as number | null,
+      priority: plugin.settings.defaultPriority,
+    };
+    render(
+      <ImportModalContent
+        plugin={plugin}
+        schedule={schedule}
+        defaultCopyOnImport={
+          this.defaultCopyOnImport ?? plugin.settings.copyOnImport
+        }
+        onClose={(args) => {
+          if (args !== 'cancel') {
+            void this.handleClose(
+              args.strategy,
+              args.value,
+              args.makeCopy
+            ).finally(() => this.close());
+          } else {
+            this.close();
+          }
+        }}
+      />,
+      contentEl
+    );
+  }
+
+  onClose() {
+    render(null, this.contentEl);
+  }
+}

--- a/src/views/SchedulingModal.tsx
+++ b/src/views/SchedulingModal.tsx
@@ -1,108 +1,70 @@
 import { invalidateItemQuery } from '#/lib/query-client';
 import type {
   ReviewArticle,
-  ReviewSnippet,
   ReviewText,
   SchedulingStrategy,
 } from '#/lib/types';
 import type IncrementalReadingPlugin from '#/main';
-import type { TFile } from 'obsidian';
 import { Modal } from 'obsidian';
 import { render } from 'preact';
 import { SchedulingModalContent } from '../components/SchedulingModalContent';
 
 export class SchedulingModal extends Modal {
   plugin: IncrementalReadingPlugin;
-  file: TFile;
-  data: ReviewText['data'] | null;
+  item: ReviewText;
 
-  constructor(
-    plugin: IncrementalReadingPlugin,
-    item: { file: TFile; data: ReviewText['data'] | null }
-  ) {
+  constructor(plugin: IncrementalReadingPlugin, item: ReviewText) {
     super(plugin.app);
     this.plugin = plugin;
-    this.file = item.file;
-    this.data = item.data;
+    this.item = item;
   }
 
   async handleClose(strategy: SchedulingStrategy, value: number) {
-    const { plugin, file, data } = this;
-    if (data === null) {
-      // item doesn't exist, so import it as an article
-      const props: [priority: number, intervalDays: number | null] =
-        strategy === 'priority'
-          ? [value, null]
-          : [plugin.settings.defaultPriority, value];
-      const importedArticle = await plugin.reviewManager.importArticle(
-        file,
-        ...props
-      );
-      if (!importedArticle) {
-        throw new Error(`Failed to import article ${file.path}`);
-      }
+    const { plugin, item } = this;
+    const promises = [];
 
-      if (plugin.settings.reviewOnImport) {
-        await plugin.learn(importedArticle);
-      }
-    } else {
-      const item: ReviewText =
-        data.type === 'article'
-          ? ({ file, data } satisfies ReviewArticle)
-          : ({ file, data } satisfies ReviewSnippet);
-      const promises = [];
-      // item already exists, so update its properties
-
-      if (strategy === 'priority') {
-        if (
-          item.data.type === 'article' &&
-          item.data.fixed_interval_days !== null
-        ) {
-          promises.push(
-            plugin.actions.manageFixedInterval(item as ReviewArticle, {
-              newPriority: value,
-            })
-          );
-        } else {
-          promises.push(plugin.actions.reprioritize(item, value));
-        }
-      } else {
-        // fixed-interval strategy
-        if (item.data.type !== 'article') {
-          throw new TypeError(
-            `Attempted to set a fixed interval on ${data.reference}, but this can only be set on articles`
-          );
-        }
+    if (strategy === 'priority') {
+      if (
+        item.data.type === 'article' &&
+        item.data.fixed_interval_days !== null
+      ) {
         promises.push(
           plugin.actions.manageFixedInterval(item as ReviewArticle, {
-            newIntervalDays: value,
+            newPriority: value,
           })
         );
+      } else {
+        promises.push(plugin.actions.reprioritize(item, value));
       }
-
-      await Promise.all(promises);
-      // invalidate cache for immediate updates
-      await invalidateItemQuery(item.data.id);
+    } else {
+      // fixed-interval strategy
+      if (item.data.type !== 'article') {
+        throw new TypeError(
+          `Attempted to set a fixed interval on ${item.data.reference}, but this can only be set on articles`
+        );
+      }
+      promises.push(
+        plugin.actions.manageFixedInterval(item as ReviewArticle, {
+          newIntervalDays: value,
+        })
+      );
     }
+
+    await Promise.all(promises);
+    await invalidateItemQuery(item.data.id);
   }
 
   onOpen() {
-    const { plugin, contentEl, data } = this;
+    const { plugin, item, contentEl } = this;
+    const { data } = item;
     const schedule = {
-      intervalDays: null as number | null,
-      priority: plugin.settings.defaultPriority,
+      intervalDays: data.type === 'article' ? data.fixed_interval_days : null,
+      priority: data.priority,
     };
-
-    if (data) {
-      schedule.priority = data.priority;
-      if (data.type === 'article') {
-        schedule.intervalDays = data.fixed_interval_days;
-      }
-    }
     render(
       <SchedulingModalContent
         plugin={plugin}
-        type={data ? data.type : 'article'}
+        type={data.type}
         schedule={schedule}
         onClose={(args) => {
           if (args !== 'cancel') {
@@ -119,7 +81,6 @@ export class SchedulingModal extends Modal {
   }
 
   onClose() {
-    const { contentEl } = this;
-    render(null, contentEl);
+    render(null, this.contentEl);
   }
 }

--- a/src/views/SchedulingModal.tsx
+++ b/src/views/SchedulingModal.tsx
@@ -109,6 +109,8 @@ export class SchedulingModal extends Modal {
             void this.handleClose(args.strategy, args.value).finally(() =>
               this.close()
             );
+          } else {
+            this.close();
           }
         }}
       />,


### PR DESCRIPTION
New features:
- Items can be moved out of the plugin's data directory
- Articles can now be imported in-place
- Setting to choose default import strategy (copy vs. in-place)
- Commands and context menu entries to override the settings for import strategy and showing import modal
- Settings to toggle the new commands and context menu entries

Fixes and other changes:
- Refactored `SchedulingModal` into two classes for importing a new item vs adjusting scheduling on an existing item
- Fixed non-functional Cancel button on `SchedulingModal`
- Fixed a bug where `FixedIntervalField` wouldn't update the displayed value if the interval changed elsewhere.
- Other minor fixes