### PR TITLE
Undoing

### DIFF
--- a/scripts/setup-obsidian.ps1
+++ b/scripts/setup-obsidian.ps1
@@ -20,7 +20,8 @@
 
 .NOTES
     Environment Variables:
-      OBSIDIAN_VERSION  - Specify a fixed version (e.g., 1.8.10). If not set, uses latest
+      OBSIDIAN_VERSION  - Specify a fixed version (e.g., 1.8.10). If not set, uses the
+                          latest desktop version from the repo's desktop-releases.json
       OBSIDIAN_PATH     - Override the path to local Obsidian installation
 #>
 
@@ -81,7 +82,19 @@ else {
 
     $version = $env:OBSIDIAN_VERSION
     if (-not $version) {
-        $version = "latest"
+        # GitHub's "latest release" can be mobile-only (v1.13.8 shipped just an .apk),
+        # so resolve the newest desktop version from the repo's own manifest instead.
+        $manifestVersion = & gh api -H "Accept: application/vnd.github.raw" "repos/obsidianmd/obsidian-releases/contents/desktop-releases.json" --jq ".latestVersion"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to resolve latest Obsidian desktop version"
+            exit 1
+        }
+        $version = ($manifestVersion | Select-Object -First 1)
+        if ($version) { $version = $version.Trim() }
+        if (-not $version) {
+            Write-Error "Could not resolve latest Obsidian desktop version"
+            exit 1
+        }
     }
 
     Write-Host "Downloading Obsidian ($version) via gh CLI" -ForegroundColor Yellow
@@ -89,15 +102,10 @@ else {
     # Download the Windows installer (.exe)
     $pattern = "Obsidian-*.exe"
 
-    if ($version -eq "latest") {
-        & gh release download -R obsidianmd/obsidian-releases --pattern $pattern --dir $tmpDir
-    }
-    else {
-        & gh release download -R obsidianmd/obsidian-releases --pattern $pattern --dir $tmpDir --tag "v$version"
-    }
+    & gh release download -R obsidianmd/obsidian-releases --pattern $pattern --dir $tmpDir --tag "v$version"
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to download Obsidian"
+        Write-Error "Failed to download Obsidian (v$version)"
         exit 1
     }
 

--- a/scripts/setup-obsidian.ps1
+++ b/scripts/setup-obsidian.ps1
@@ -102,7 +102,8 @@ else {
     # Download the Windows installer (.exe)
     $pattern = "Obsidian-*.exe"
 
-    & gh release download -R obsidianmd/obsidian-releases --pattern $pattern --dir $tmpDir --tag "v$version"
+    # NB: gh takes the tag as a positional arg; there is no --tag flag.
+    & gh release download "v$version" -R obsidianmd/obsidian-releases --pattern $pattern --dir $tmpDir
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to download Obsidian (v$version)"

--- a/scripts/setup-obsidian.sh
+++ b/scripts/setup-obsidian.sh
@@ -10,7 +10,8 @@
 # USAGE (ci)    : ./scripts/setup-obsidian.sh --ci
 #
 # Environment Variables
-#   OBSIDIAN_VERSION  Specify a fixed version (e.g., 1.8.10). If not set, uses latest
+#   OBSIDIAN_VERSION  Specify a fixed version (e.g., 1.8.10). If not set, uses the
+#                     latest desktop version from the repo's desktop-releases.json
 #   OBSIDIAN_PATH     Override the path to local Obsidian installation
 #
 set -euo pipefail
@@ -74,6 +75,18 @@ else
   tmp_dir="$(mktemp -d)"
   version="${OBSIDIAN_VERSION:-latest}"
 
+  if [[ "$version" == "latest" ]]; then
+    # GitHub's "latest release" can be mobile-only (v1.13.8 shipped just an .apk),
+    # so resolve the newest desktop version from the repo's own manifest instead.
+    version="$(gh api -H 'Accept: application/vnd.github.raw' \
+      repos/obsidianmd/obsidian-releases/contents/desktop-releases.json \
+      --jq .latestVersion)"
+    [[ -n "$version" ]] || {
+      echo "❌ Could not resolve latest Obsidian desktop version" >&2
+      exit 1
+    }
+  fi
+
   if [[ "$PLATFORM" == "macos" ]]; then
     # macOS: universal DMG works for both Intel and Apple Silicon
     pattern="Obsidian-*.dmg"
@@ -92,13 +105,8 @@ else
     echo "⏬ Downloading Obsidian ($version) AppImage for $arch via gh CLI"
   fi
 
-  if [[ "$version" == "latest" ]]; then
-    gh release download -R obsidianmd/obsidian-releases \
-      --pattern "$pattern" --dir "$tmp_dir"
-  else
-    gh release download -R obsidianmd/obsidian-releases \
-      --pattern "$pattern" --dir "$tmp_dir" --tag "v${version}"
-  fi
+  gh release download -R obsidianmd/obsidian-releases \
+    --pattern "$pattern" --dir "$tmp_dir" --tag "v${version}"
 
   # On x86_64, remove the arm64 AppImage if both were downloaded
   if [[ "$PLATFORM" == "linux" && "$arch" == "x86_64" ]]; then

--- a/scripts/setup-obsidian.sh
+++ b/scripts/setup-obsidian.sh
@@ -105,8 +105,9 @@ else
     echo "⏬ Downloading Obsidian ($version) AppImage for $arch via gh CLI"
   fi
 
-  gh release download -R obsidianmd/obsidian-releases \
-    --pattern "$pattern" --dir "$tmp_dir" --tag "v${version}"
+  # NB: gh takes the tag as a positional arg; there is no --tag flag.
+  gh release download "v${version}" -R obsidianmd/obsidian-releases \
+    --pattern "$pattern" --dir "$tmp_dir"
 
   # On x86_64, remove the arm64 AppImage if both were downloaded
   if [[ "$PLATFORM" == "linux" && "$arch" == "x86_64" ]]; then

--- a/src/components/IREditor.test.ts
+++ b/src/components/IREditor.test.ts
@@ -1,11 +1,14 @@
 // @vitest-environment jsdom
 
-import { isPersistableChange } from '#/components/IREditor';
+import {
+  computeMinimalChange,
+  isPersistableChange,
+} from '#/components/IREditor';
 import { isExternalSync } from '#/lib/extensions/SnippetHighlightExtension';
 import { EditorSelection, EditorState } from '@codemirror/state';
 import { EditorView, type ViewUpdate } from '@codemirror/view';
 import fc from 'fast-check';
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // #region HELPERS
 
@@ -44,36 +47,332 @@ function captureUpdate(
  * Mirror of the updateEditorContent dispatch in IREditor.tsx.
  * Keep in sync with that implementation.
  */
-function dispatchFullReplacement(view: EditorView, newContent: string): void {
-  const newLength = newContent.length;
-  const clampedSelection = EditorSelection.create(
-    view.state.selection.ranges.map((r) =>
-      EditorSelection.range(
-        Math.min(r.anchor, newLength),
-        Math.min(r.head, newLength)
-      )
-    ),
-    view.state.selection.mainIndex
-  );
+function dispatchExternalSync(view: EditorView, newContent: string): void {
+  const change = computeMinimalChange(view.state.doc.toString(), newContent);
+  if (!change) return;
   const { scrollTop, scrollLeft } = view.scrollDOM;
   view.dispatch({
-    changes: { from: 0, to: view.state.doc.length, insert: newContent },
-    selection: clampedSelection,
+    changes: change,
     annotations: isExternalSync.of(true),
   });
   view.scrollDOM.scrollTop = scrollTop;
   view.scrollDOM.scrollLeft = scrollLeft;
 }
 
+/**
+ * Models the full updateEditorContent guard:
+ *   skip if value === currentDoc  (no change at all)
+ *   skip if value === lastSaved   (stale echo of our own save)
+ *   apply otherwise               (genuine external change)
+ *
+ * Returns true if the replacement was applied, false if skipped.
+ */
+function conditionalReplacement(
+  view: EditorView,
+  value: string,
+  lastSavedContent: string
+): boolean {
+  if (view.state.doc.toString() === value) return false;
+  if (value === lastSavedContent) return false;
+  dispatchExternalSync(view, value);
+  return true;
+}
+
+/** Applies a change the way CodeMirror's ChangeSet does, for round-tripping. */
+function applyChange(
+  current: string,
+  change: { from: number; to: number; insert: string }
+): string {
+  return (
+    current.slice(0, change.from) + change.insert + current.slice(change.to)
+  );
+}
+
+const isHighSurrogate = (code: number) => code >= 0xd800 && code <= 0xdbff;
+const isLowSurrogate = (code: number) => code >= 0xdc00 && code <= 0xdfff;
+
+/** True when position `i` falls between the two halves of a surrogate pair. */
+function splitsSurrogatePair(text: string, i: number): boolean {
+  return (
+    isHighSurrogate(text.charCodeAt(i - 1)) &&
+    isLowSurrogate(text.charCodeAt(i))
+  );
+}
+
+/**
+ * A document built from a shared head, a differing middle, and a shared tail —
+ * the shape every real external sync takes, since a note edited elsewhere keeps
+ * most of its text.
+ */
+const localEditArb = fc
+  .record({
+    head: fc.string({ minLength: 1, maxLength: 60 }),
+    tail: fc.string({ minLength: 1, maxLength: 60 }),
+    oldMiddle: fc.string({ minLength: 1, maxLength: 30 }),
+    newMiddle: fc.string({ minLength: 1, maxLength: 30 }),
+  })
+  // The middles must differ at both ends, or the algorithm legitimately
+  // absorbs the matching characters into the shared prefix/suffix and the
+  // exact boundary assertions below would not hold.
+  .filter(
+    ({ oldMiddle, newMiddle }) =>
+      oldMiddle[0] !== newMiddle[0] &&
+      oldMiddle[oldMiddle.length - 1] !== newMiddle[newMiddle.length - 1]
+  );
+
 // #endregion
 
+describe('computeMinimalChange narrows a whole-document swap to the differing span', () => {
+  it('returns null when the incoming text already matches the document', () => {
+    expect(computeMinimalChange('same text', 'same text')).toBeNull();
+  });
+
+  it('returns null for two empty strings', () => {
+    expect(computeMinimalChange('', '')).toBeNull();
+  });
+
+  it('reports the exact span when a card line is undone out of the middle of a note', () => {
+    const before = 'intro\ncard line\noutro';
+    const after = 'intro\noutro';
+
+    expect(computeMinimalChange(before, after)).toEqual({
+      from: 6,
+      to: 16,
+      insert: '',
+    });
+  });
+
+  it('reports an insertion as a zero-width replacement at the insertion point', () => {
+    expect(computeMinimalChange('ab', 'aXb')).toEqual({
+      from: 1,
+      to: 1,
+      insert: 'X',
+    });
+  });
+
+  it('replaces the whole document when nothing at all is shared', () => {
+    expect(computeMinimalChange('abc', 'xyz')).toEqual({
+      from: 0,
+      to: 3,
+      insert: 'xyz',
+    });
+  });
+
+  it('reconstructs the incoming text exactly (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ unit: 'binary', maxLength: 120 }),
+        fc.string({ unit: 'binary', maxLength: 120 }),
+        async (current, next) => {
+          const change = computeMinimalChange(current, next);
+          // A null result must mean the texts already match; anything else
+          // would silently drop an external edit.
+          if (change === null) {
+            expect(current).toBe(next);
+            return;
+          }
+          expect(applyChange(current, change)).toBe(next);
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  it('keeps from and to inside the current document and in order (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ unit: 'binary', maxLength: 120 }),
+        fc.string({ unit: 'binary', maxLength: 120 }),
+        async (current, next) => {
+          const change = computeMinimalChange(current, next);
+          if (change === null) return;
+          expect(change.from).toBeGreaterThanOrEqual(0);
+          expect(change.to).toBeGreaterThanOrEqual(change.from);
+          expect(change.to).toBeLessThanOrEqual(current.length);
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  it('leaves the shared head and tail outside the changed span (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        localEditArb,
+        async ({ head, tail, oldMiddle, newMiddle }) => {
+          const current = head + oldMiddle + tail;
+          const next = head + newMiddle + tail;
+
+          const change = computeMinimalChange(current, next);
+
+          // Anything less than this and the scroll anchor — a position in the
+          // head — would fall inside the deleted range and collapse.
+          expect(change).not.toBeNull();
+          expect(change!.from).toBeGreaterThanOrEqual(head.length);
+          expect(change!.to).toBeLessThanOrEqual(
+            head.length + oldMiddle.length
+          );
+        }
+      ),
+      { numRuns: 300 }
+    );
+  });
+
+  it('never places a boundary inside a surrogate pair (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ unit: 'binary', maxLength: 80 }),
+        fc.string({ unit: 'binary', maxLength: 80 }),
+        async (current, next) => {
+          const change = computeMinimalChange(current, next);
+          if (change === null) return;
+          // A boundary inside an astral character hands CodeMirror a position
+          // that is not a valid cursor location.
+          expect(splitsSurrogatePair(current, change.from)).toBe(false);
+          expect(splitsSurrogatePair(current, change.to)).toBe(false);
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  it('widens past a shared astral character rather than splitting it', () => {
+    // Both strings start with the same emoji, so a naive scan would stop the
+    // prefix between its two code units.
+    const change = computeMinimalChange('\u{1F600}a', '\u{1F600}b');
+
+    expect(change).toEqual({ from: 2, to: 3, insert: 'b' });
+  });
+
+  it('widens when the two texts share only the leading half of a pair', () => {
+    // \u{1F600} and \u{1F601} share their high surrogate but differ in the low
+    // one, so the scan would otherwise cut the pair in half.
+    const change = computeMinimalChange('\u{1F600}', '\u{1F601}');
+
+    expect(change).not.toBeNull();
+    expect(change!.from).toBe(0);
+    expect(applyChange('\u{1F600}', change!)).toBe('\u{1F601}');
+  });
+
+  it('widens when the two texts share only the trailing half of a pair', () => {
+    // \u{1F600} is D83D DE00 and \u{1FA00} is D83E DE00: the suffix scan matches
+    // the shared low surrogate and stops mid-pair, putting the boundary between
+    // the halves of the character still in the document.
+    const change = computeMinimalChange('\u{1F600}', '\u{1FA00}');
+
+    expect(change).toEqual({ from: 0, to: 2, insert: '\u{1FA00}' });
+  });
+
+  it('handles astral characters that share either surrogate half (property-based)', async () => {
+    // Emoji drawn at random almost never share a surrogate half, so a pool of
+    // characters chosen to share one or the other is needed to reach the
+    // boundary adjustments at all. D83D DE00 / D83E DE00 share the low half;
+    // D83D DE00 / D83D DE01 share the high half.
+    const astralText = fc
+      .array(
+        fc.constantFrom(
+          '\u{1F600}',
+          '\u{1FA00}',
+          '\u{1F601}',
+          '\u{1F9A0}',
+          'a',
+          '\n'
+        ),
+        { maxLength: 12 }
+      )
+      .map((chars) => chars.join(''));
+
+    await fc.assert(
+      fc.asyncProperty(astralText, astralText, async (current, next) => {
+        const change = computeMinimalChange(current, next);
+        if (change === null) {
+          expect(current).toBe(next);
+          return;
+        }
+        expect(applyChange(current, change)).toBe(next);
+        expect(splitsSurrogatePair(current, change.from)).toBe(false);
+        expect(splitsSurrogatePair(current, change.to)).toBe(false);
+      }),
+      { numRuns: 1000 }
+    );
+  });
+});
+
+describe('updateEditorContent keeps CodeMirror scroll anchor mappable', () => {
+  // CodeMirror holds the viewport still by remapping the position of the line
+  // at the top of the screen through the ChangeSet. These tests assert on that
+  // mapping directly: jsdom has no layout, so scrollTop itself proves nothing.
+
+  const makeDoc = (lines: number, marker = 'body') =>
+    Array.from({ length: lines }, (_, i) => `line ${i} ${marker}`).join('\n');
+
+  it('maps a viewport-top anchor to itself when the edit is below it', () => {
+    const before = makeDoc(60);
+    const after = before.replace('line 50 body', 'line 50 edited elsewhere');
+    const anchorPos = before.indexOf('line 30 body');
+
+    const update = captureUpdate(before, (view) =>
+      dispatchExternalSync(view, after)
+    );
+
+    // The regression: a full-document replacement collapsed this to 0, and the
+    // next measure pass scrolled line 0 back under the viewport top.
+    expect(update.changes.mapPos(anchorPos, -1)).toBe(anchorPos);
+  });
+
+  it('maps a viewport-top anchor onto the same line when the edit is above it', () => {
+    const before = makeDoc(60);
+    const after = before.replace('line 10 body', 'line 10 body\ninserted line');
+    const anchorPos = before.indexOf('line 30 body');
+
+    const update = captureUpdate(before, (view) =>
+      dispatchExternalSync(view, after)
+    );
+
+    const mapped = update.changes.mapPos(anchorPos, -1);
+
+    // The anchor shifts by the inserted text, which is exactly what lets
+    // CodeMirror adjust scrollTop so the line stays put on screen.
+    expect(mapped).toBe(anchorPos + '\ninserted line'.length);
+    expect(after.slice(mapped, mapped + 'line 30 body'.length)).toBe(
+      'line 30 body'
+    );
+  });
+
+  it('maps an anchor at any untouched position to itself (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        localEditArb.chain((edit) =>
+          fc.record({
+            edit: fc.constant(edit),
+            // Any position within the shared head, where a scroll anchor above
+            // the edit would sit.
+            anchorPos: fc.integer({ min: 0, max: edit.head.length }),
+          })
+        ),
+        async ({ edit, anchorPos }) => {
+          const { head, tail, oldMiddle, newMiddle } = edit;
+          const current = head + oldMiddle + tail;
+
+          const update = captureUpdate(current, (view) =>
+            dispatchExternalSync(view, head + newMiddle + tail)
+          );
+
+          expect(update.changes.mapPos(anchorPos, -1)).toBe(anchorPos);
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+});
+
 describe('isPersistableChange keeps fetched content from being written back', () => {
-  it('rejects the full-document replacement updateEditorContent dispatches', () => {
-    // The regression: this replacement carries text fetched for whichever item
-    // is current now, while the editor still saves to the item it mounted
-    // with. Persisting it overwrites that item's note with the other's text.
+  it('rejects the change updateEditorContent dispatches', () => {
+    // The regression: this carries text fetched for whichever item is current
+    // now, while the editor still saves to the item it mounted with.
+    // Persisting it overwrites that item's note with the other's text.
     const update = captureUpdate('article body', (view) =>
-      dispatchFullReplacement(view, 'card body {{answer}}')
+      dispatchExternalSync(view, 'card body {{answer}}')
     );
 
     expect(isPersistableChange(update)).toBe(false);
@@ -108,7 +407,7 @@ describe('isPersistableChange keeps fetched content from being written back', ()
     expect(isPersistableChange(update)).toBe(false);
   });
 
-  it('rejects any replacement carrying the external-sync annotation, whatever the content (property-based)', async () => {
+  it('rejects any sync carrying the external-sync annotation, whatever the content (property-based)', async () => {
     await fc.assert(
       fc.asyncProperty(
         fc
@@ -119,7 +418,7 @@ describe('isPersistableChange keeps fetched content from being written back', ()
           .filter(([initial, incoming]) => initial !== incoming),
         async ([initial, incoming]) => {
           const update = captureUpdate(initial, (view) =>
-            dispatchFullReplacement(view, incoming)
+            dispatchExternalSync(view, incoming)
           );
 
           // Every value pushed in from outside is already on disk, so none of
@@ -147,55 +446,87 @@ describe('isPersistableChange keeps fetched content from being written back', ()
 });
 
 describe('updateEditorContent preserves cursor position', () => {
-  afterEach(() => {
-    // Views are destroyed at the end of each test; nothing global to clean up.
-  });
-
-  it('preserves cursor at position 5 after replacement with equal-length content', () => {
-    const view = makeView('hello world'); // length 11
-    view.dispatch({ selection: EditorSelection.cursor(5) });
-    expect(view.state.selection.main.head).toBe(5); // precondition
-
-    dispatchFullReplacement(view, 'HELLO WORLD');
-
-    // Bug: resets to 0. Fix: maps cursor through changes → stays at 5.
-    expect(view.state.selection.main.head).toBe(5);
-    view.destroy();
-  });
-
-  it('preserves selection range [2, 7] after replacement with longer content', () => {
-    const view = makeView('abcdefghij'); // length 10
-    view.dispatch({ selection: EditorSelection.range(2, 7) });
-    expect(view.state.selection.main.anchor).toBe(2); // precondition
-    expect(view.state.selection.main.head).toBe(7); // precondition
-
-    dispatchFullReplacement(view, 'abcdefghijklmno'); // length 15
-
-    // Bug: both reset to 0. Fix: selection maps through changes.
-    expect(view.state.selection.main.anchor).toBe(2);
-    expect(view.state.selection.main.head).toBe(7);
-    view.destroy();
-  });
-
-  it('preserves cursor when replacement content is identical to current doc', () => {
-    const view = makeView('hello');
+  it('leaves a cursor sitting before the edit exactly where it was', () => {
+    const view = makeView('intro\ncard line\noutro');
     view.dispatch({ selection: EditorSelection.cursor(3) });
 
-    dispatchFullReplacement(view, 'hello');
+    dispatchExternalSync(view, 'intro\noutro');
 
-    expect(view.state.doc.toString()).toBe('hello');
     expect(view.state.selection.main.head).toBe(3);
     view.destroy();
   });
 
-  it('preserves cursor at an arbitrary position after replacement with arbitrary content (property-based)', async () => {
+  it('shifts a cursor sitting after the edit by the length the edit removed', () => {
+    const before = 'intro\ncard line\noutro';
+    const view = makeView(before);
+    const cursor = before.indexOf('outro') + 2;
+    view.dispatch({ selection: EditorSelection.cursor(cursor) });
+
+    dispatchExternalSync(view, 'intro\noutro');
+
+    // 'card line\n' (10 chars) disappeared from above the cursor, so the
+    // cursor must move back by 10 to stay on the same character.
+    expect(view.state.selection.main.head).toBe(cursor - 10);
+    expect(
+      view.state.doc.toString().slice(0, view.state.selection.main.head)
+    ).toBe('intro\nou');
+    view.destroy();
+  });
+
+  it('keeps a selection range anchored to the same characters across an edit above it', () => {
+    const before = 'HEAD\nmiddle\nTAIL';
+    const view = makeView(before);
+    const anchor = before.indexOf('TAIL');
+    view.dispatch({ selection: EditorSelection.range(anchor, anchor + 4) });
+
+    dispatchExternalSync(view, 'HEAD\nmiddle text\nTAIL');
+
+    const { from, to } = view.state.selection.main;
+    expect(view.state.doc.toString().slice(from, to)).toBe('TAIL');
+    view.destroy();
+  });
+
+  it('keeps the cursor on the same character for any edit above it (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        localEditArb,
+        async ({ head, tail, oldMiddle, newMiddle }) => {
+          const current = head + oldMiddle + tail;
+          const view = makeView(current);
+          // Cursor in the tail, i.e. below the edit.
+          const cursor = head.length + oldMiddle.length + tail.length;
+          view.dispatch({ selection: EditorSelection.cursor(cursor) });
+
+          dispatchExternalSync(view, head + newMiddle + tail);
+
+          expect(view.state.selection.main.head).toBe(
+            head.length + newMiddle.length + tail.length
+          );
+          view.destroy();
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+
+  it('clamps the cursor into the document when the incoming text is empty', () => {
+    const view = makeView('hello world');
+    view.dispatch({ selection: EditorSelection.cursor(6) });
+
+    dispatchExternalSync(view, '');
+
+    expect(view.state.doc.toString()).toBe('');
+    expect(view.state.selection.main.head).toBe(0);
+    view.destroy();
+  });
+
+  it('leaves the cursor inside the document for any incoming text (property-based)', async () => {
     await fc.assert(
       fc.asyncProperty(
         fc.string({ minLength: 2, maxLength: 200 }).chain((initial) =>
           fc.record({
             initialContent: fc.constant(initial),
-            cursorPos: fc.integer({ min: 1, max: initial.length }),
-            // filter ensures newContent !== initial so the early-return guard does not fire
+            cursorPos: fc.integer({ min: 0, max: initial.length }),
             newContent: fc
               .string({ minLength: 0, maxLength: 200 })
               .filter((s) => s !== initial),
@@ -205,45 +536,19 @@ describe('updateEditorContent preserves cursor position', () => {
           const view = makeView(initialContent);
           view.dispatch({ selection: EditorSelection.cursor(cursorPos) });
 
-          dispatchFullReplacement(view, newContent);
+          dispatchExternalSync(view, newContent);
 
-          // A correct implementation maps the cursor through the ChangeSet.
-          // A full deletion maps any position to 0 (the insertion point), so the
-          // cursor should land at min(cursorPos, newContent.length).
-          const expectedHead = Math.min(cursorPos, newContent.length);
-          // Bug: head is always 0 for any cursorPos > 0 when newContent.length >= 1.
-          expect(view.state.selection.main.head).toBe(expectedHead);
-
+          expect(view.state.doc.toString()).toBe(newContent);
+          expect(view.state.selection.main.head).toBeGreaterThanOrEqual(0);
+          expect(view.state.selection.main.head).toBeLessThanOrEqual(
+            newContent.length
+          );
           view.destroy();
         }
       )
     );
   });
 });
-
-// ---------------------------------------------------------------------------
-// Helper that mirrors the full updateEditorContent guard logic, including the
-// lastSavedContent check. Keep in sync with IREditor.tsx updateEditorContent.
-// ---------------------------------------------------------------------------
-
-/**
- * Models the full updateEditorContent guard:
- *   skip if value === currentDoc  (no change at all)
- *   skip if value === lastSaved   (stale echo of our own save)
- *   apply otherwise               (genuine external change)
- *
- * Returns true if the replacement was applied, false if skipped.
- */
-function conditionalReplacement(
-  view: EditorView,
-  value: string,
-  lastSavedContent: string
-): boolean {
-  if (view.state.doc.toString() === value) return false;
-  if (value === lastSavedContent) return false;
-  dispatchFullReplacement(view, value);
-  return true;
-}
 
 describe('updateEditorContent skips stale own-save echoes and applies genuine external changes', () => {
   it('does not apply a replacement when the fetched value equals the last saved content (own-save echo)', () => {
@@ -332,139 +637,12 @@ describe('updateEditorContent restores scrollDOM scroll position after replaceme
           // Ensure the dispatch actually fires (content must differ from current doc).
           const content =
             newContent !== initialContent ? newContent : newContent + '\x00';
-          dispatchFullReplacement(view, content);
+          dispatchExternalSync(view, content);
 
-          // A correct implementation saves scroll before dispatch and restores it
-          // after. Assert the final observable state, not the call sequence —
-          // using the getter confirms the value that actually stuck.
+          // Keeping scrollTop equal to the value CodeMirror recorded at its
+          // last measure is what stops it discarding the scroll anchor.
           expect(view.scrollDOM.scrollTop).toBe(scrollTop);
           expect(view.scrollDOM.scrollLeft).toBe(scrollLeft);
-
-          view.destroy();
-        }
-      )
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Edge cases for dispatchFullReplacement cursor/selection clamping
-// ---------------------------------------------------------------------------
-
-describe('updateEditorContent clamps cursor to empty replacement content', () => {
-  it('clamps cursor to 0 when replacement content is empty string', () => {
-    const view = makeView('hello world');
-    view.dispatch({ selection: EditorSelection.cursor(6) });
-    expect(view.state.selection.main.head).toBe(6); // precondition
-
-    dispatchFullReplacement(view, '');
-
-    expect(view.state.doc.toString()).toBe('');
-    expect(view.state.selection.main.head).toBe(0);
-    view.destroy();
-  });
-
-  it('clamps cursor to 0 when replacement content is empty string (property-based)', async () => {
-    await fc.assert(
-      fc.asyncProperty(
-        fc.string({ minLength: 1, maxLength: 200 }).chain((initial) =>
-          fc.record({
-            initialContent: fc.constant(initial),
-            cursorPos: fc.integer({ min: 0, max: initial.length }),
-          })
-        ),
-        async ({ initialContent, cursorPos }) => {
-          const view = makeView(initialContent);
-          view.dispatch({ selection: EditorSelection.cursor(cursorPos) });
-
-          dispatchFullReplacement(view, '');
-
-          expect(view.state.doc.toString()).toBe('');
-          // Any cursor position clamped to min(pos, 0) === 0.
-          expect(view.state.selection.main.head).toBe(0);
-
-          view.destroy();
-        }
-      )
-    );
-  });
-});
-
-describe('updateEditorContent clamps selection endpoints independently', () => {
-  // Note: jsdom's EditorView enforces allowMultipleSelections=false, so only
-  // single-range selections are possible in this environment. Multi-range
-  // behavior in dispatchFullReplacement is a trivial extension of the
-  // single-range map — if clamping is correct for one range it is correct
-  // for N (same Math.min per endpoint logic applied by the .map() call).
-
-  it('clamps only the out-of-bounds head of a range when anchor is within bounds', () => {
-    // Range [3, 9] in a 10-char doc. Replacement is 6 chars.
-    // anchor=3 fits (3 <= 6), head=9 does not (9 > 6) → head clamped to 6.
-    const view = makeView('0123456789'); // length 10
-    view.dispatch({ selection: EditorSelection.range(3, 9) });
-
-    dispatchFullReplacement(view, '012345'); // length 6
-
-    expect(view.state.selection.main.anchor).toBe(3);
-    expect(view.state.selection.main.head).toBe(6);
-    view.destroy();
-  });
-
-  it('clamps both anchor and head when both exceed the new document length (property-based)', async () => {
-    await fc.assert(
-      fc.asyncProperty(
-        // initial doc long enough for an out-of-bounds range
-        fc.string({ minLength: 10, maxLength: 200 }).chain((initial) =>
-          fc.record({
-            initialContent: fc.constant(initial),
-            // anchor and head both well beyond any possible newContent
-            anchor: fc.integer({ min: Math.ceil(initial.length * 0.8), max: initial.length }),
-            head: fc.integer({ min: Math.ceil(initial.length * 0.8), max: initial.length }),
-            // newContent is short so both anchor and head exceed its length
-            newContent: fc.string({ minLength: 0, maxLength: Math.floor(initial.length * 0.7) }),
-          })
-        ),
-        async ({ initialContent, anchor, head, newContent }) => {
-          const view = makeView(initialContent);
-          view.dispatch({ selection: EditorSelection.range(anchor, head) });
-
-          dispatchFullReplacement(view, newContent);
-
-          const newLen = newContent.length;
-          expect(view.state.selection.main.anchor).toBe(Math.min(anchor, newLen));
-          expect(view.state.selection.main.head).toBe(Math.min(head, newLen));
-
-          view.destroy();
-        }
-      )
-    );
-  });
-
-  it('leaves anchor and head unchanged when both fit within the new document length (property-based)', async () => {
-    await fc.assert(
-      fc.asyncProperty(
-        fc.string({ minLength: 10, maxLength: 200 }).chain((initial) =>
-          fc.string({ minLength: initial.length, maxLength: initial.length + 100 })
-            .filter((s) => s !== initial)
-            .chain((newContent) =>
-              fc.record({
-                initialContent: fc.constant(initial),
-                newContent: fc.constant(newContent),
-                // anchor and head both well within the new (longer) content
-                anchor: fc.integer({ min: 0, max: initial.length }),
-                head: fc.integer({ min: 0, max: initial.length }),
-              })
-            )
-        ),
-        async ({ initialContent, newContent, anchor, head }) => {
-          const view = makeView(initialContent);
-          view.dispatch({ selection: EditorSelection.range(anchor, head) });
-
-          dispatchFullReplacement(view, newContent);
-
-          // Both endpoints fit — no clamping should occur.
-          expect(view.state.selection.main.anchor).toBe(anchor);
-          expect(view.state.selection.main.head).toBe(head);
 
           view.destroy();
         }
@@ -484,7 +662,11 @@ describe('updateEditorContent skips when currentDoc already equals the incoming 
 
     // value === currentDoc, so conditionalReplacement must short-circuit
     // before reaching the `value === lastSaved` check.
-    const applied = conditionalReplacement(view, currentContent, 'something else');
+    const applied = conditionalReplacement(
+      view,
+      currentContent,
+      'something else'
+    );
 
     expect(applied).toBe(false);
     expect(view.state.doc.toString()).toBe(currentContent);
@@ -519,7 +701,7 @@ describe('updateEditorContent skips when currentDoc already equals the incoming 
 });
 
 describe('updateEditorContent applies genuine external changes (property-based)', () => {
-  it('applies replacement and clamps cursor when value differs from both currentDoc and lastSaved (property-based)', async () => {
+  it('applies the change when value differs from both currentDoc and lastSaved (property-based)', async () => {
     await fc.assert(
       fc.asyncProperty(
         fc.string({ minLength: 0, maxLength: 100 }).chain((editorContent) =>
@@ -535,7 +717,10 @@ describe('updateEditorContent applies genuine external changes (property-based)'
                     editorContent: fc.constant(editorContent),
                     lastSaved: fc.constant(lastSaved),
                     externalValue: fc.constant(externalValue),
-                    cursorPos: fc.integer({ min: 0, max: Math.max(editorContent.length, 0) }),
+                    cursorPos: fc.integer({
+                      min: 0,
+                      max: Math.max(editorContent.length, 0),
+                    }),
                   })
                 )
             )
@@ -545,14 +730,19 @@ describe('updateEditorContent applies genuine external changes (property-based)'
           const clampedCursor = Math.min(cursorPos, editorContent.length);
           view.dispatch({ selection: EditorSelection.cursor(clampedCursor) });
 
-          const applied = conditionalReplacement(view, externalValue, lastSaved);
+          const applied = conditionalReplacement(
+            view,
+            externalValue,
+            lastSaved
+          );
 
           // Must have applied the change.
           expect(applied).toBe(true);
           expect(view.state.doc.toString()).toBe(externalValue);
           // Cursor must land within the new document bounds.
-          const expectedHead = Math.min(clampedCursor, externalValue.length);
-          expect(view.state.selection.main.head).toBe(expectedHead);
+          expect(view.state.selection.main.head).toBeLessThanOrEqual(
+            externalValue.length
+          );
           view.destroy();
         }
       ),

--- a/src/components/IREditor.test.ts
+++ b/src/components/IREditor.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
+import { isPersistableChange } from '#/components/IREditor';
 import { isExternalSync } from '#/lib/extensions/SnippetHighlightExtension';
 import { EditorSelection, EditorState } from '@codemirror/state';
-import { EditorView } from '@codemirror/view';
+import { EditorView, type ViewUpdate } from '@codemirror/view';
 import fc from 'fast-check';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -11,6 +12,32 @@ import { afterEach, describe, expect, it } from 'vitest';
 function makeView(doc: string): EditorView {
   const state = EditorState.create({ doc });
   return new EditorView({ state, parent: document.body });
+}
+
+/**
+ * Capture the ViewUpdate produced by `dispatch`, the same object IREditor's
+ * `onUpdate` override receives.
+ */
+function captureUpdate(
+  doc: string,
+  dispatch: (view: EditorView) => void
+): ViewUpdate {
+  let captured: ViewUpdate | null = null;
+  const view = new EditorView({
+    state: EditorState.create({
+      doc,
+      extensions: [
+        EditorView.updateListener.of((update) => {
+          captured = update;
+        }),
+      ],
+    }),
+    parent: document.body,
+  });
+  dispatch(view);
+  view.destroy();
+  if (captured === null) throw new Error('no ViewUpdate was produced');
+  return captured;
 }
 
 /**
@@ -39,6 +66,85 @@ function dispatchFullReplacement(view: EditorView, newContent: string): void {
 }
 
 // #endregion
+
+describe('isPersistableChange keeps fetched content from being written back', () => {
+  it('rejects the full-document replacement updateEditorContent dispatches', () => {
+    // The regression: this replacement carries text fetched for whichever item
+    // is current now, while the editor still saves to the item it mounted
+    // with. Persisting it overwrites that item's note with the other's text.
+    const update = captureUpdate('article body', (view) =>
+      dispatchFullReplacement(view, 'card body {{answer}}')
+    );
+
+    expect(isPersistableChange(update)).toBe(false);
+  });
+
+  it('accepts a change the user typed', () => {
+    const update = captureUpdate('article body', (view) =>
+      view.dispatch({
+        changes: { from: 12, insert: ' extended' },
+        userEvent: 'input.type',
+      })
+    );
+
+    expect(isPersistableChange(update)).toBe(true);
+  });
+
+  it('accepts a user edit that arrives without a userEvent annotation', () => {
+    // Editor commands and plugin-issued edits often carry no userEvent. They
+    // are still this editor's own content and must reach disk.
+    const update = captureUpdate('article body', (view) =>
+      view.dispatch({ changes: { from: 0, insert: '# ' } })
+    );
+
+    expect(isPersistableChange(update)).toBe(true);
+  });
+
+  it('rejects a selection-only update', () => {
+    const update = captureUpdate('article body', (view) =>
+      view.dispatch({ selection: EditorSelection.cursor(3) })
+    );
+
+    expect(isPersistableChange(update)).toBe(false);
+  });
+
+  it('rejects any replacement carrying the external-sync annotation, whatever the content (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .tuple(
+            fc.string({ minLength: 0, maxLength: 200 }),
+            fc.string({ minLength: 0, maxLength: 200 })
+          )
+          .filter(([initial, incoming]) => initial !== incoming),
+        async ([initial, incoming]) => {
+          const update = captureUpdate(initial, (view) =>
+            dispatchFullReplacement(view, incoming)
+          );
+
+          // Every value pushed in from outside is already on disk, so none of
+          // them may be saved — regardless of which item's file it came from.
+          expect(isPersistableChange(update)).toBe(false);
+        }
+      )
+    );
+  });
+
+  it('accepts every unannotated document change (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 1, maxLength: 100 }),
+        async (inserted) => {
+          const update = captureUpdate('doc', (view) =>
+            view.dispatch({ changes: { from: 0, insert: inserted } })
+          );
+
+          expect(isPersistableChange(update)).toBe(true);
+        }
+      )
+    );
+  });
+});
 
 describe('updateEditorContent preserves cursor position', () => {
   afterEach(() => {

--- a/src/components/IREditor.tsx
+++ b/src/components/IREditor.tsx
@@ -120,9 +120,9 @@ export function IREditor({
     if (!isPersistableChange(update)) return;
 
     const docText = update.state.doc.toString();
+    lastSavedContentRef.current = docText;
     // TODO: don't save if changes occurred outside review
     await saveNote(itemRef.current, docText);
-    lastSavedContentRef.current = docText;
   };
 
   // extend the MarkdownEditor extracted from Obsidian

--- a/src/components/IREditor.tsx
+++ b/src/components/IREditor.tsx
@@ -367,10 +367,10 @@ export function IREditor({
               error
             );
           }
-          elRef.current?.removeChild(elRef.current?.children[0]);
-          internalRef.current = null;
-          if (editorRef) editorRef.current = null;
         }
+        elRef.current?.removeChild(elRef.current?.children[0]);
+        internalRef.current = null;
+        if (editorRef) editorRef.current = null;
       };
       return cleanupEffect;
     };

--- a/src/components/IREditor.tsx
+++ b/src/components/IREditor.tsx
@@ -68,6 +68,21 @@ interface IREditorProps {
   placeholder?: string;
 }
 
+/**
+ * Whether a document change originated in this editor and so belongs on disk.
+ *
+ * `updateEditorContent` pushes freshly fetched file text in as a full-document
+ * replacement, which reaches `onUpdate` looking exactly like typing. Writing
+ * that back would save content the editor was *handed* into whichever note the
+ * editor is currently pointed at, so any moment where the displayed text and
+ * the target note disagree becomes an overwrite of the target. Content that
+ * came from disk never needs to be written to disk, so it is skipped.
+ */
+export function isPersistableChange(update: ViewUpdate): boolean {
+  if (!update.docChanged) return false;
+  return !update.transactions.some((tr) => tr.annotation(isExternalSync));
+}
+
 export function IREditor({
   item,
   editorRef,
@@ -93,8 +108,16 @@ export function IREditor({
   // genuine external modification (apply).
   const lastSavedContentRef = useRef<string>(value ?? '');
 
+  // The current-item query refetches on an interval and after every mutation,
+  // so `item` is a new object — with a possibly renamed TFile — on many
+  // renders even though its id, and therefore this mount, stays the same.
+  // Saves must land on the latest one.
+  useEffect(() => {
+    itemRef.current = item;
+  }, [item]);
+
   const handleChange = async (update: ViewUpdate) => {
-    if (!update.docChanged) return;
+    if (!isPersistableChange(update)) return;
 
     const docText = update.state.doc.toString();
     // TODO: don't save if changes occurred outside review
@@ -233,7 +256,7 @@ export function IREditor({
       const controller = getMarkdownController(
         reviewView,
         () => editor.editor,
-        itemRef.current
+        () => itemRef.current
       );
       try {
         editor = new CustomEditor(app, elRef.current, controller);
@@ -364,10 +387,7 @@ export function IREditor({
 
       const view = internalRef.current;
       const currentDoc = view.state.doc.toString();
-      if (
-        currentDoc !== value &&
-        value !== lastSavedContentRef.current
-      ) {
+      if (currentDoc !== value && value !== lastSavedContentRef.current) {
         const newContent = value ?? '';
         const newLength = newContent.length;
         // Clamp each range's anchor and head to the new document length.

--- a/src/components/IREditor.tsx
+++ b/src/components/IREditor.tsx
@@ -83,6 +83,65 @@ export function isPersistableChange(update: ViewUpdate): boolean {
   return !update.transactions.some((tr) => tr.annotation(isExternalSync));
 }
 
+const isHighSurrogate = (code: number) => code >= 0xd800 && code <= 0xdbff;
+const isLowSurrogate = (code: number) => code >= 0xdc00 && code <= 0xdfff;
+
+/**
+ * The narrowest replacement that turns `current` into `next`, or `null` when
+ * they already match.
+ *
+ * CodeMirror holds the viewport still across a document change by remembering
+ * the line at the top of the screen and re-locating it afterwards: `ViewState`
+ * saves `scrollAnchorPos = changes.mapPos(anchor.from, -1)`, then the next
+ * measure pass shifts `scrollDOM.scrollTop` by however far that line moved. A
+ * `{from: 0, to: doc.length}` replacement deletes the anchor along with the
+ * rest of the document, so `mapPos` collapses it to 0 and the measure pass
+ * dutifully scrolls line 0 back under the viewport top — the jump to the top of
+ * the note. That correction lands on the next animation frame, which is why
+ * restoring `scrollTop` by hand right after the dispatch cannot prevent it.
+ *
+ * Trimming the shared prefix and suffix leaves the anchor outside the changed
+ * range, where it maps to itself. It also lets the selection map correctly
+ * instead of collapsing, and spares undo history and decorations from a
+ * needless rebuild.
+ */
+export function computeMinimalChange(
+  current: string,
+  next: string
+): { from: number; to: number; insert: string } | null {
+  if (current === next) return null;
+
+  const shorter = Math.min(current.length, next.length);
+  let prefix = 0;
+  while (
+    prefix < shorter &&
+    current.charCodeAt(prefix) === next.charCodeAt(prefix)
+  ) {
+    prefix++;
+  }
+  let suffix = 0;
+  while (
+    suffix < shorter - prefix &&
+    current.charCodeAt(current.length - 1 - suffix) ===
+      next.charCodeAt(next.length - 1 - suffix)
+  ) {
+    suffix++;
+  }
+
+  // Both boundaries are code-unit offsets, so either can land between the
+  // halves of a surrogate pair and hand CodeMirror a position inside an
+  // astral character. Widening the changed range by one unit swallows the pair
+  // whole; it can never underflow, since `charCodeAt` off either end is NaN.
+  if (isHighSurrogate(current.charCodeAt(prefix - 1))) prefix--;
+  if (isLowSurrogate(current.charCodeAt(current.length - suffix))) suffix--;
+
+  return {
+    from: prefix,
+    to: current.length - suffix,
+    insert: next.slice(prefix, next.length - suffix),
+  };
+}
+
 export function IREditor({
   item,
   editorRef,
@@ -387,31 +446,26 @@ export function IREditor({
 
       const view = internalRef.current;
       const currentDoc = view.state.doc.toString();
-      if (currentDoc !== value && value !== lastSavedContentRef.current) {
-        const newContent = value ?? '';
-        const newLength = newContent.length;
-        // Clamp each range's anchor and head to the new document length.
-        // We can't use selection.map(changes) here because a full-document
-        // replacement maps every position inside the deleted span to 0 via
-        // mapPos — which would lose the cursor position entirely.
-        const clampedSelection = EditorSelection.create(
-          view.state.selection.ranges.map((r) =>
-            EditorSelection.range(
-              Math.min(r.anchor, newLength),
-              Math.min(r.head, newLength)
-            )
-          ),
-          view.state.selection.mainIndex
-        );
-        const { scrollTop, scrollLeft } = view.scrollDOM;
-        view.dispatch({
-          changes: { from: 0, to: view.state.doc.length, insert: newContent },
-          selection: clampedSelection,
-          annotations: isExternalSync.of(true),
-        });
-        view.scrollDOM.scrollTop = scrollTop;
-        view.scrollDOM.scrollLeft = scrollLeft;
-      }
+      if (currentDoc === value || value === lastSavedContentRef.current) return;
+
+      const change = computeMinimalChange(currentDoc, value ?? '');
+      if (!change) return;
+
+      // No `selection` is passed: with the change narrowed to the span that
+      // actually differs, CodeMirror's own mapping moves the cursor by exactly
+      // the amount the text before it grew or shrank.
+      const { scrollTop, scrollLeft } = view.scrollDOM;
+      view.dispatch({
+        changes: change,
+        annotations: isExternalSync.of(true),
+      });
+      // The scroll anchor is only honoured while `scrollDOM.scrollTop` still
+      // agrees with the value CodeMirror recorded at its last measure; a
+      // disagreement of more than a pixel makes it discard the anchor. Putting
+      // back whatever the DOM rewrite disturbed is what keeps the correction
+      // above armed.
+      view.scrollDOM.scrollTop = scrollTop;
+      view.scrollDOM.scrollLeft = scrollLeft;
     },
     [value]
   );

--- a/src/components/ReviewContext.test.tsx
+++ b/src/components/ReviewContext.test.tsx
@@ -1,0 +1,333 @@
+// @vitest-environment jsdom
+import { ReviewContextProvider, useReviewContext } from '#/components/ReviewContext';
+import { ObsidianHelpers } from '#/lib/ObsidianHelpers';
+import { queryClient } from '#/lib/query-client';
+import type { ReviewItem } from '#/lib/types';
+import fc from 'fast-check';
+import { render } from 'preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #region HELPERS
+
+type SaveNote = (item: ReviewItem, newContent: string) => Promise<void>;
+
+interface Highlight {
+  id: string;
+  start_offset: number;
+  end_offset: number;
+}
+
+/** The key `useCurrentItemFileText` reads the review editor's `value` from. */
+function fileTextKey(itemId: string) {
+  return ['item', itemId, 'file-text'];
+}
+
+function makeItem(id: string, path = 'IR/Articles/source.md'): ReviewItem {
+  return { data: { id }, file: { path } } as unknown as ReviewItem;
+}
+
+/**
+ * Stand-in for `ReviewManager` covering what `saveNote` touches: the highlight
+ * offsets it reads before writing, and the persistence call it makes after.
+ */
+function makeReviewManager(highlights: Highlight[] = []) {
+  return {
+    snippets: {
+      offsetTracker: { getHighlights: vi.fn(() => highlights) },
+    },
+    updateSnippetOffsets: vi.fn(async () => undefined),
+  };
+}
+
+/**
+ * Render the provider and hand back the `saveNote` it publishes. Preact's
+ * initial render is synchronous, so the ref is populated by the time this
+ * returns.
+ */
+function captureSaveNote(reviewManager: ReturnType<typeof makeReviewManager>) {
+  const ref: { current: SaveNote | null } = { current: null };
+
+  function Capture() {
+    ref.current = useReviewContext().saveNote;
+    return null;
+  }
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  render(
+    (
+      <ReviewContextProvider
+        plugin={{} as never}
+        reviewView={{ app: {} } as never}
+        reviewManager={reviewManager as never}
+      >
+        <Capture />
+      </ReviewContextProvider>
+    ) as never,
+    container
+  );
+
+  if (!ref.current) throw new Error('saveNote was not provided by the context');
+  return ref.current;
+}
+
+// #endregion
+
+// react-redux is mocked rather than spied on because its exports are
+// non-configurable: `vi.spyOn(ReactRedux, 'useDispatch')` throws
+// "Cannot redefine property". This is the documented cannot-be-spied case.
+const dispatch = vi.fn();
+vi.mock('react-redux', () => ({
+  useDispatch: () => dispatch,
+}));
+
+describe('saveNote publishes its write to the file-text cache', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    vi.spyOn(ObsidianHelpers, 'editNote').mockResolvedValue('');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    dispatch.mockClear();
+    queryClient.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('caches the text it just wrote, so restoring the file to the pre-save text is still seen as a change', async () => {
+    // The regression, in the shape it actually occurred: an article is open in
+    // review, a card is extracted (replacing a line with a transclusion), then
+    // the extraction is undone. The undo restores the file to `original` — the
+    // exact text the cache held at mount. Unless the save published
+    // `withEmbed`, the refetch after the undo returns a string identical to the
+    // cached one, `value` never changes, and IREditor's `[value]` effect never
+    // runs: the editor keeps showing the embed for a card that no longer exists.
+    const original = '- a line of prose\n';
+    const withEmbed = '- ![[Card abc123|ir-hide-title]]\n';
+    queryClient.setQueryData(fileTextKey('article-1'), original);
+
+    const saveNote = captureSaveNote(makeReviewManager());
+    await saveNote(makeItem('article-1'), withEmbed);
+
+    expect(queryClient.getQueryData(fileTextKey('article-1'))).toBe(withEmbed);
+    // The property that makes the undo observable: a later read of `original`
+    // is no longer equal to what the cache holds.
+    expect(queryClient.getQueryData(fileTextKey('article-1'))).not.toBe(
+      original
+    );
+  });
+
+  it('caches whatever text was written, for any item id and any preceding cached text (property-based)', async () => {
+    const saveNote = captureSaveNote(makeReviewManager());
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 1, maxLength: 60 }),
+        fc.string({ maxLength: 400 }),
+        fc.string({ maxLength: 400 }),
+        async (itemId, cachedBefore, written) => {
+          queryClient.clear();
+          queryClient.setQueryData(fileTextKey(itemId), cachedBefore);
+
+          await saveNote(makeItem(itemId), written);
+
+          expect(queryClient.getQueryData(fileTextKey(itemId))).toBe(written);
+        }
+      )
+    );
+  });
+
+  it('seeds the cache entry when the item has never been fetched', async () => {
+    // A save can land before anything read the file — the write-through has to
+    // create the entry rather than assume one exists.
+    const saveNote = captureSaveNote(makeReviewManager());
+
+    await saveNote(makeItem('never-fetched'), 'body text');
+
+    expect(queryClient.getQueryData(fileTextKey('never-fetched'))).toBe(
+      'body text'
+    );
+  });
+
+  it('writes only the saved item entry, leaving other items untouched (property-based)', async () => {
+    const saveNote = captureSaveNote(makeReviewManager());
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .tuple(
+            fc.string({ minLength: 1, maxLength: 40 }),
+            fc.string({ minLength: 1, maxLength: 40 })
+          )
+          .filter(([saved, other]) => saved !== other),
+        fc.string({ maxLength: 200 }),
+        fc.string({ maxLength: 200 }),
+        async ([savedId, otherId], otherText, written) => {
+          queryClient.clear();
+          queryClient.setQueryData(fileTextKey(otherId), otherText);
+
+          await saveNote(makeItem(savedId), written);
+
+          // Cross-item bleed would put one note's text in front of another
+          // note's file, and the review editor writes back what it displays.
+          expect(queryClient.getQueryData(fileTextKey(otherId))).toBe(otherText);
+        }
+      )
+    );
+  });
+
+  it('leaves the cache untouched when the write to disk fails', async () => {
+    // The cache stands in for what is on disk. Publishing text that never
+    // landed would make a later refetch of the real content look like an
+    // external edit, and the editor would be resynced to it.
+    const original = 'on disk';
+    queryClient.setQueryData(fileTextKey('article-1'), original);
+    vi.spyOn(ObsidianHelpers, 'editNote').mockRejectedValue(
+      new Error('write failed')
+    );
+
+    const saveNote = captureSaveNote(makeReviewManager());
+
+    await expect(saveNote(makeItem('article-1'), 'never reached')).rejects.toThrow(
+      'write failed'
+    );
+    expect(queryClient.getQueryData(fileTextKey('article-1'))).toBe(original);
+  });
+
+  it('writes the note before publishing to the cache', async () => {
+    // Ordering matters for the same reason as the failure case: the cache must
+    // never describe a state disk has not reached.
+    const order: string[] = [];
+    vi.spyOn(ObsidianHelpers, 'editNote').mockImplementation(async () => {
+      order.push('editNote');
+      return '';
+    });
+    const saveNote = captureSaveNote(makeReviewManager());
+
+    await saveNote(makeItem('article-1'), 'new body');
+    order.push(
+      queryClient.getQueryData(fileTextKey('article-1')) === 'new body'
+        ? 'cached'
+        : 'not cached'
+    );
+
+    expect(order).toEqual(['editNote', 'cached']);
+  });
+
+  it('passes the saved text to editNote as the new file content', async () => {
+    const editNote = vi
+      .spyOn(ObsidianHelpers, 'editNote')
+      .mockResolvedValue('');
+    const saveNote = captureSaveNote(makeReviewManager());
+    const item = makeItem('article-1', 'IR/Articles/target.md');
+
+    await saveNote(item, 'replacement body');
+
+    expect(editNote).toHaveBeenCalledTimes(1);
+    const [, file, transform] = editNote.mock.calls[0];
+    expect(file).toBe(item.file);
+    // The transform ignores current content: saveNote replaces the whole note.
+    expect((transform as (data: string) => string)('anything at all')).toBe(
+      'replacement body'
+    );
+  });
+
+  it('persists every highlight offset read before the write (property-based)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(
+          fc.record({
+            id: fc.string({ minLength: 1, maxLength: 20 }),
+            start_offset: fc.integer({ min: 0, max: 10_000 }),
+            end_offset: fc.integer({ min: 0, max: 10_000 }),
+          }),
+          { maxLength: 8 }
+        ),
+        async (highlights) => {
+          queryClient.clear();
+          const reviewManager = makeReviewManager(highlights);
+          const saveNote = captureSaveNote(reviewManager);
+
+          await saveNote(makeItem('article-1'), 'body');
+
+          expect(reviewManager.updateSnippetOffsets).toHaveBeenCalledTimes(
+            highlights.length
+          );
+          highlights.forEach((h, i) => {
+            expect(reviewManager.updateSnippetOffsets).toHaveBeenNthCalledWith(
+              i + 1,
+              h.id,
+              h.start_offset,
+              h.end_offset
+            );
+          });
+        }
+      )
+    );
+  });
+});
+
+describe('useReviewContext', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('throws when read outside the provider', () => {
+    // Returning null instead would hand every consumer an undefined saveNote,
+    // and the failure would surface later as a note that silently stops saving.
+    function Orphan() {
+      useReviewContext();
+      return null;
+    }
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    expect(() => render((<Orphan />) as never, container)).toThrow(
+      'Review context can only be accessed within its provider'
+    );
+  });
+});
+
+describe('saveNote suppresses external-modification handling around its own write', () => {
+  beforeEach(() => {
+    queryClient.clear();
+    vi.spyOn(ObsidianHelpers, 'editNote').mockResolvedValue('');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    dispatch.mockClear();
+    queryClient.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('raises the saving flag before writing and lowers it after', async () => {
+    // While raised, the vault modify handler skips invalidation — that is what
+    // keeps the editor's own write from bouncing back through a refetch.
+    const saveNote = captureSaveNote(makeReviewManager());
+
+    await saveNote(makeItem('article-1'), 'body');
+
+    const payloads = dispatch.mock.calls.map(
+      ([action]) => (action as { payload: boolean }).payload
+    );
+    expect(payloads).toEqual([true, false]);
+  });
+
+  it('lowers the saving flag even when the write throws', async () => {
+    // A flag left raised would disable external-edit syncing for the rest of
+    // the session, silently.
+    vi.spyOn(ObsidianHelpers, 'editNote').mockRejectedValue(
+      new Error('write failed')
+    );
+    const saveNote = captureSaveNote(makeReviewManager());
+
+    await expect(saveNote(makeItem('article-1'), 'body')).rejects.toThrow();
+
+    const payloads = dispatch.mock.calls.map(
+      ([action]) => (action as { payload: boolean }).payload
+    );
+    expect(payloads).toEqual([true, false]);
+  });
+});

--- a/src/components/ReviewContext.tsx
+++ b/src/components/ReviewContext.tsx
@@ -1,6 +1,7 @@
 import type { Actions } from '#/lib/Actions';
 import { ObsidianHelpers as Obsidian } from '#/lib/ObsidianHelpers';
 import type ReviewManager from '#/lib/items/ReviewManager';
+import { queryClient } from '#/lib/query-client';
 import { setReviewViewSaving } from '#/lib/store';
 import type { ReviewItem } from '#/lib/types';
 import type IncrementalReadingPlugin from '#/main';
@@ -53,6 +54,7 @@ export function ReviewContextProvider({
 
     await withReviewViewSave(async () => {
       await Obsidian.editNote(reviewView.app, item.file, () => newContent);
+      queryClient.setQueryData(['item', item.data.id, 'file-text'], newContent);
     });
     // Save body-relative highlight offsets
     for (const h of highlights) {

--- a/src/components/ReviewInterface.tsx
+++ b/src/components/ReviewInterface.tsx
@@ -1,5 +1,4 @@
 import { useAppSelector } from '#/hooks/useAppSelector';
-import { useCurrentItem } from '#/hooks/useReactQuery';
 import type ReviewManager from '#/lib/items/ReviewManager';
 import { queryClient } from '#/lib/query-client';
 import type IncrementalReadingPlugin from '#/main';
@@ -33,18 +32,7 @@ function ReviewInterface() {
   return (
     <div className={'ir-review-interface view-content'}>
       <ActionBar />
-      {page === 'home' ? <ReviewHome /> : <ReviewItemView />}
+      {page === 'home' ? <ReviewHome /> : <ReviewItem />}
     </div>
-  );
-}
-
-/** The single-item review flow, reached by clicking a queue row. */
-function ReviewItemView() {
-  const { data: item } = useCurrentItem();
-
-  return item ? (
-    <ReviewItem item={item} />
-  ) : (
-    <div className="ir-review-placeholder">Nothing due for review.</div>
   );
 }

--- a/src/components/ReviewItem.tsx
+++ b/src/components/ReviewItem.tsx
@@ -1,6 +1,6 @@
 import { useAppSelector } from '#/hooks/useAppSelector';
 import { useCurrentItemFileText } from '#/hooks/useReactQuery';
-import { isReviewCard, type ReviewItem } from '#/lib/types';
+import { isReviewCard } from '#/lib/types';
 import type { EditorView } from '@codemirror/view';
 import { CardViewer } from './CardViewer';
 import { IREditor } from './IREditor';
@@ -11,12 +11,13 @@ import { IREditor } from './IREditor';
  * - loading spinner?
  * - error element
  */
-export default function ReviewItem({ item }: { item: ReviewItem }) {
+export default function ReviewItem() {
   const showAnswer = useAppSelector((state) => state.showAnswer);
 
-  const { data: fileText } = useCurrentItemFileText();
+  const { item, text: fileText } = useCurrentItemFileText();
 
-  if (!fileText) return <></>;
+  if (!item || !fileText)
+    return <div className="ir-review-placeholder">Nothing due for review.</div>;
   return (
     <>
       {isReviewCard(item) && !showAnswer ? (

--- a/src/components/action-bar/ActionBar.test.tsx
+++ b/src/components/action-bar/ActionBar.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
+import { ReviewContextProvider } from '#/components/ReviewContext';
 import type { QueuePage } from '#/components/types';
 import * as ReactQuery from '#/hooks/useReactQuery';
+import type { ActionStackEntry } from '#/lib/Actions';
 import type { ComponentChild } from 'preact';
 import { render } from 'preact';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ActionBar } from './ActionBar';
 
 // #region HELPERS
@@ -52,6 +54,68 @@ function beginReviewButton(container: HTMLElement): HTMLButtonElement {
   return button;
 }
 
+function undoButton(container: HTMLElement): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>('#undo-button');
+  if (!button) throw new Error('undo button not rendered');
+  return button;
+}
+
+/**
+ * Stand-in for `Actions` covering what the undo button touches: an array
+ * mutated in place, and an emit after each mutation. `listeners` is exposed so
+ * a test can check the button lets go of its subscription.
+ */
+function makeActions() {
+  const undoStack: ActionStackEntry[] = [];
+  const listeners = new Set<() => void>();
+  const emit = () => {
+    listeners.forEach((fn) => fn());
+  };
+  return {
+    undoStack,
+    listeners,
+    subscribe: (fn: () => void) => {
+      listeners.add(fn);
+      return () => void listeners.delete(fn);
+    },
+    setCardsOnly: vi.fn(),
+    undo: vi.fn(() => {
+      undoStack.pop();
+      emit();
+    }),
+    push: (description: string) => {
+      undoStack.push({ description } as ActionStackEntry);
+      emit();
+    },
+  };
+}
+
+/** Mount the bar on the review page, where the undo button lives. */
+function mountReviewBar(actions: ReturnType<typeof makeActions>): HTMLElement {
+  reduxState.page = 'review';
+  vi.spyOn(ReactQuery, 'useCurrentItem').mockReturnValue({
+    data: undefined,
+  } as never);
+  return mount(
+    <ReviewContextProvider
+      plugin={{ actions } as never}
+      reviewView={{} as never}
+      reviewManager={{} as never}
+    >
+      <ActionBar />
+    </ReviewContextProvider>
+  );
+}
+
+/**
+ * Let preact catch up. Long enough to cover the deferred effect that subscribes
+ * (preact falls back to a 100ms timeout when no frame is painted), and awaited
+ * so the re-render an emit schedules lands before the next assertion.
+ */
+async function settle() {
+  await vi.advanceTimersByTimeAsync(200);
+}
+
 // #endregion
 
 // lucide-react resolves `useContext` against its own preact copy, which is not
@@ -67,25 +131,32 @@ vi.mock('lucide-react', () => ({
   Scissors: () => null,
   SkipForward: () => null,
   Trash2: () => null,
+  Undo2: () => null,
 }));
 
 // react-redux is mocked rather than spied on because its exports are
 // non-configurable: `vi.spyOn(ReactRedux, 'useDispatch')` throws
 // "Cannot redefine property". This is the documented cannot-be-spied case.
 const dispatch = vi.fn();
+// The bar branches on `state.page`, so tests set it before mounting. Read
+// through the selector at render time, which is after this initializes.
+const defaultReduxState = {
+  page: 'home' as 'home' | 'review',
+  showAnswer: false,
+  typesToReview: { article: true, snippet: true, card: true },
+};
+const reduxState = { ...defaultReduxState };
 vi.mock('react-redux', () => ({
   useDispatch: () => dispatch,
-  // The bar branches on `state.page`; 'home' is the screen the begin-review
-  // button lives on, and the only one these tests are about.
-  useSelector: (selector: (state: unknown) => unknown) =>
-    selector({ page: 'home', showAnswer: false }),
-  useStore: () => ({ getState: () => ({ page: 'home' }) }),
+  useSelector: (selector: (state: unknown) => unknown) => selector(reduxState),
+  useStore: () => ({ getState: () => reduxState }),
 }));
 
 describe('ActionBar', () => {
   afterEach(() => {
     document.body.innerHTML = '';
     dispatch.mockClear();
+    Object.assign(reduxState, defaultReduxState);
     vi.restoreAllMocks();
   });
 
@@ -144,6 +215,127 @@ describe('ActionBar', () => {
       expect(beginReviewButton(container).getAttribute('aria-label')).toBe(
         'Nothing due for review'
       );
+    });
+  });
+
+  describe('undo button', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('is disabled when no action has been taken', async () => {
+      const container = mountReviewBar(makeActions());
+      await settle();
+
+      expect(undoButton(container).disabled).toBe(true);
+    });
+
+    it('explains why it is unavailable when there is nothing to undo', async () => {
+      const container = mountReviewBar(makeActions());
+      await settle();
+
+      expect(undoButton(container).getAttribute('aria-label')).toBe(
+        'Nothing to undo'
+      );
+    });
+
+    it('enables itself when an action is recorded, with no other re-render', async () => {
+      // Regression: creating a snippet pushes onto the undo stack without
+      // touching the store, so nothing else re-renders the bar. The button
+      // stayed disabled until an unrelated render (leaving and re-entering
+      // review) happened to pick the new entry up.
+      const actions = makeActions();
+      const container = mountReviewBar(actions);
+      await settle();
+      expect(undoButton(container).disabled).toBe(true);
+
+      actions.push('creating snippet "excerpt"');
+      await settle();
+
+      expect(undoButton(container).disabled).toBe(false);
+    });
+
+    it('names the recorded action once it appears', async () => {
+      const actions = makeActions();
+      const container = mountReviewBar(actions);
+      await settle();
+
+      actions.push('creating snippet "excerpt"');
+      await settle();
+
+      expect(undoButton(container).getAttribute('aria-label')).toBe(
+        'Undo creating snippet "excerpt"'
+      );
+    });
+
+    it('follows the top of the stack rather than the first entry', async () => {
+      const actions = makeActions();
+      const container = mountReviewBar(actions);
+      actions.push('skipping "first"');
+      await settle();
+
+      actions.push('creating snippet "second"');
+      await settle();
+
+      expect(undoButton(container).getAttribute('aria-label')).toBe(
+        'Undo creating snippet "second"'
+      );
+    });
+
+    it('disables itself again once the stack is emptied', async () => {
+      const actions = makeActions();
+      const container = mountReviewBar(actions);
+      actions.push('creating snippet "excerpt"');
+      await settle();
+      expect(undoButton(container).disabled).toBe(false);
+
+      undoButton(container).click();
+      await settle();
+
+      expect(undoButton(container).disabled).toBe(true);
+    });
+
+    it('reverses the recorded action when clicked', async () => {
+      const actions = makeActions();
+      const container = mountReviewBar(actions);
+      actions.push('creating snippet "excerpt"');
+      await settle();
+
+      undoButton(container).click();
+
+      expect(actions.undo).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops its subscription when unmounted', async () => {
+      const actions = makeActions();
+      const container = mountReviewBar(actions);
+      await settle();
+      expect(actions.listeners.size).toBe(1);
+
+      render(null, container);
+      await settle();
+
+      expect(actions.listeners.size).toBe(0);
+    });
+
+    it('subscribes once across re-renders', async () => {
+      // The subscription is torn down and rebuilt whenever `subscribe` changes
+      // identity, so an unstable one would churn on every render.
+      const actions = makeActions();
+      const container = mountReviewBar(actions);
+      await settle();
+
+      actions.push('skipping "first"');
+      await settle();
+      actions.push('skipping "second"');
+      await settle();
+
+      expect(undoButton(container).disabled).toBe(false);
+      expect(actions.listeners.size).toBe(1);
     });
   });
 });

--- a/src/components/action-bar/ActionBar.tsx
+++ b/src/components/action-bar/ActionBar.tsx
@@ -1,5 +1,6 @@
 import { useAppSelector } from '#/hooks/useAppSelector';
 import { useCurrentItem, useQueue } from '#/hooks/useReactQuery';
+import type { ActionStackEntry } from '#/lib/Actions';
 import { QUEUE_TABLE_DEFAULT_ENTRIES_PER_PAGE } from '#/lib/constants';
 import { setPage, setShowAnswer } from '#/lib/store';
 import type { ReviewItem, ReviewText } from '#/lib/types';
@@ -22,7 +23,9 @@ import {
   Scissors,
   SkipForward,
   Trash2,
+  Undo2,
 } from 'lucide-react';
+import { useSyncExternalStore } from 'react';
 import { useDispatch } from 'react-redux';
 import { Rating } from 'ts-fsrs';
 import { useReviewContext } from '../ReviewContext';
@@ -52,6 +55,7 @@ export function ActionBar() {
           </ButtonWithIcon>
           <Separator />
           <ReviewTypeFilter />
+          <UndoAction />
           {currentItem && (
             <>
               {isReviewCard(currentItem) && <CardActions card={currentItem} />}
@@ -112,10 +116,44 @@ function HomeActions() {
  * - always render ActionBar once a global action exists
  * - forward/back (or use the view header)
  * - view queue
- * - undo last review/dismissal
  */
 function GlobalActions() {
   return <></>;
+}
+
+/**
+ * Reverses the most recent undoable action.
+ *
+ * The stack lives on the `Actions` instance rather than in the store, since its
+ * entries hold closures, so it announces its own changes and this subscribes.
+ * Rendering off the store instead would miss the actions that change no store
+ * state — creating a snippet, notably.
+ */
+function UndoAction() {
+  const { actions } = useReviewContext();
+  // The top entry, not the stack: `push`/`pop` mutate the array in place, so
+  // its reference never changes and every snapshot would compare equal. The
+  // entry is a fresh object per action and is all this button renders, so its
+  // identity changes exactly when the button's appearance should.
+  const lastAction: ActionStackEntry | undefined = useSyncExternalStore(
+    actions.subscribe,
+    () => actions.undoStack[actions.undoStack.length - 1]
+  );
+
+  return (
+    <ButtonWithIcon
+      tooltip={
+        lastAction ? `Undo ${lastAction.description}` : 'Nothing to undo'
+      }
+      id="undo-button"
+      disabled={lastAction === undefined}
+      handleClick={async () => {
+        await actions.undo();
+      }}
+    >
+      <Undo2 />
+    </ButtonWithIcon>
+  );
 }
 
 /**

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -86,8 +86,8 @@ CREATE INDEX IF NOT EXISTS srs_card_due ON srs_card(due);
 CREATE TABLE IF NOT EXISTS srs_card_review (
   id TEXT NOT NULL, -- UUID
   card_id TEXT NOT NULL REFERENCES srs_card(id),
-  due INTEGER NOT NULL,
-  review INTEGER NOT NULL,
+  due INTEGER NOT NULL, -- time it was due
+  review INTEGER NOT NULL, -- actual time of review
   stability REAL NOT NULL,
   difficulty REAL NOT NULL,
   elapsed_days REAL NOT NULL,

--- a/src/hooks/useReactQuery.tsx
+++ b/src/hooks/useReactQuery.tsx
@@ -5,6 +5,7 @@ import {
   currentItemQueryFn,
   invalidateCurrentItemQuery,
 } from '#/lib/query-client';
+import type { ReviewItem } from '#/lib/types';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useAppSelector } from './useAppSelector';
@@ -53,11 +54,22 @@ export function useCurrentItem() {
   return result;
 }
 
-export function useCurrentItemFileText() {
+/**
+ * The current item's file text, together with the item it was read from.
+ * The text is cached per item id, so the returned `item` is always the one
+ * this render keyed the fetch on; pairing the text with an item taken from
+ * anywhere else (a prop, an earlier render) can put one item's content in
+ * front of another item's file, and the review editor writes back what it
+ * displays.
+ */
+export function useCurrentItemFileText(): {
+  item: ReviewItem | null;
+  text: string | undefined;
+} {
   const { plugin } = useReviewContext();
   const { data: currentItem } = useCurrentItem();
 
-  return useQuery({
+  const { data: text } = useQuery({
     enabled: !!currentItem,
     queryKey: ['item', currentItem?.data.id, 'file-text'],
     queryFn: async () => {
@@ -65,4 +77,6 @@ export function useCurrentItemFileText() {
       return plugin.app.vault.read(currentItem.file);
     },
   });
+
+  return { item: currentItem ?? null, text };
 }

--- a/src/lib/Actions.test.ts
+++ b/src/lib/Actions.test.ts
@@ -56,10 +56,6 @@ function makeReviewItem(basename: string, pathOverride?: string): ReviewItem {
 
 // #endregion
 
-// ---------------------------------------------------------------------------
-// skipItem — Notice message
-// ---------------------------------------------------------------------------
-
 describe('Actions.skipItem — Notice message', () => {
   let NoticeMock: ReturnType<typeof vi.fn>;
 
@@ -121,10 +117,6 @@ describe('Actions.skipItem — Notice message', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// dismissItem — Notice message
-// ---------------------------------------------------------------------------
-
 describe('Actions.dismissItem — Notice message', () => {
   let NoticeMock: ReturnType<typeof vi.fn>;
 
@@ -176,10 +168,6 @@ describe('Actions.dismissItem — Notice message', () => {
     expect(message).toContain('...');
   });
 });
-
-// ---------------------------------------------------------------------------
-// unDismissItem — Notice message
-// ---------------------------------------------------------------------------
 
 describe('Actions.unDismissItem — Notice message', () => {
   let NoticeMock: ReturnType<typeof vi.fn>;
@@ -241,10 +229,6 @@ describe('Actions.unDismissItem — Notice message', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// skipItem — dispatch
-// ---------------------------------------------------------------------------
-
 describe('Actions.skipItem — dispatch', () => {
   let NoticeMock: ReturnType<typeof vi.fn>;
 
@@ -266,10 +250,6 @@ describe('Actions.skipItem — dispatch', () => {
     expect(plugin.store.dispatch).toHaveBeenCalledTimes(2);
   });
 });
-
-// ---------------------------------------------------------------------------
-// dismissItem — dispatch
-// ---------------------------------------------------------------------------
 
 describe('Actions.dismissItem — dispatch', () => {
   let NoticeMock: ReturnType<typeof vi.fn>;
@@ -305,10 +285,6 @@ describe('Actions.dismissItem — dispatch', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// unDismissItem — dispatch
-// ---------------------------------------------------------------------------
-
 describe('Actions.unDismissItem — dispatch', () => {
   let NoticeMock: ReturnType<typeof vi.fn>;
 
@@ -340,5 +316,95 @@ describe('Actions.unDismissItem — dispatch', () => {
     const actions = new Actions(plugin);
     await actions.unDismissItem(makeReviewItem('my-article'));
     expect(plugin.store.dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('Actions — undo stack notifications', () => {
+  let NoticeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    NoticeMock = vi.fn();
+    vi.stubGlobal('Notice', NoticeMock);
+    vi.spyOn(store, 'getState').mockReturnValue({
+      currentItemId: null,
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('notifies subscribers when a skip is recorded', () => {
+    // Regression: the stack was pushed to directly, so subscribers heard
+    // nothing and the undo button kept showing the action before it.
+    const actions = new Actions(makePlugin());
+    const listener = vi.fn();
+    actions.subscribe(listener);
+
+    actions.skipItem(makeReviewItem('my-article'));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies subscribers when a dismissal is recorded', async () => {
+    const actions = new Actions(makePlugin());
+    const listener = vi.fn();
+    actions.subscribe(listener);
+
+    await actions.dismissItem(makeReviewItem('my-article'));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies subscribers when an action is undone', async () => {
+    const actions = new Actions(makePlugin());
+    actions.skipItem(makeReviewItem('my-article'));
+    const listener = vi.fn();
+    actions.subscribe(listener);
+
+    await actions.undo();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when there is nothing to undo', async () => {
+    const actions = new Actions(makePlugin());
+    const listener = vi.fn();
+    actions.subscribe(listener);
+
+    await actions.undo();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('notifies even when the reversal itself throws', async () => {
+    // The entry is already off the stack by then, so subscribers must not be
+    // left reading an entry that is no longer there.
+    const actions = new Actions(makePlugin());
+    actions.pushUndo({
+      item: makeReviewItem('my-article'),
+      description: 'doing something reversible',
+      undo: () => {
+        throw new Error('reversal failed');
+      },
+    });
+    const listener = vi.fn();
+    actions.subscribe(listener);
+
+    await expect(actions.undo()).rejects.toThrow('reversal failed');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const actions = new Actions(makePlugin());
+    const listener = vi.fn();
+    const unsubscribe = actions.subscribe(listener);
+
+    unsubscribe();
+    actions.skipItem(makeReviewItem('my-article'));
+
+    expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -179,6 +179,16 @@ export class Actions {
     await this.plugin.reviewManager.dismissItem(item);
     await invalidateItemQuery(item.data.id);
 
+    this.pushUndo({
+      item,
+      description: `dismissing "${item.file.basename}"`,
+      undo: async () => {
+        await this.plugin.reviewManager.unDismissItem(item);
+        await invalidateItemQuery(item.data.id);
+        this.getNext();
+      },
+    });
+
     new Notice(
       `Dismissed "${getContentSlice(item.file.basename, CONTENT_TITLE_SLICE_LENGTH, true)}"`
     );

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -101,7 +101,8 @@ export class Actions {
 
   reviewSnippet = async (snippet: ReviewSnippet, nextInterval?: number) => {
     try {
-      await this.plugin.reviewManager.reviewSnippet(
+      const beforeReview = { ...snippet.data };
+      const reviewId = await this.plugin.reviewManager.reviewSnippet(
         snippet.data,
         Date.now(),
         nextInterval
@@ -117,6 +118,18 @@ export class Actions {
         );
       }
       this.getNext();
+      this.pushUndo({
+        item: snippet,
+        description: `reviewing "${snippet.file.basename}"`,
+        undo: async () => {
+          await this.plugin.reviewManager.snippets.undoReview(
+            beforeReview,
+            reviewId
+          );
+          await invalidateItemQuery(snippet.data.id);
+          this.getNext();
+        },
+      });
     } catch (error) {
       console.error(error);
     }

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -9,10 +9,12 @@ import {
   SUCCESS_NOTICE_DURATION_MS,
 } from './constants';
 import IRScheduler from './IRScheduler';
+import { ObsidianHelpers } from './ObsidianHelpers';
 import {
   fetchCurrentItem,
   invalidateCurrentItemQuery,
   invalidateItemQuery,
+  queryClient,
 } from './query-client';
 import {
   addSeenId,
@@ -314,7 +316,95 @@ export class Actions {
       this.plugin.getActiveReviewView() ??
       this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
     if (!view) return null;
+
+    const sourceFile = view.file;
+    if (!sourceFile) return null;
+
     const result = await this.plugin.reviewManager.createCard(editor, view);
+
+    if (result) {
+      const { reviewCard, line } = result;
+
+      this.pushUndo({
+        item: result.reviewCard,
+        description: `creating card "${result.reviewCard.file.basename}"`,
+        undo: async () => {
+          // restore the original text
+          const before = await this.plugin.app.vault.read(sourceFile);
+          const after = await ObsidianHelpers.editNote(
+            this.plugin.app,
+            sourceFile,
+            (data) => {
+              const cardEmbed = ObsidianHelpers.findEmbeds(
+                this.plugin.app,
+                sourceFile,
+                reviewCard.file
+              );
+
+              if (!cardEmbed) return data;
+
+              const startOffset = cardEmbed.position.start.offset;
+              const endOffset = cardEmbed.position.end.offset;
+
+              const prefix = data.slice(0, startOffset);
+              const replacement = data.slice(startOffset, endOffset);
+              console.log({ replacement, line });
+              const suffix = data.slice(endOffset);
+              return prefix + line + suffix;
+            }
+          );
+
+          console.log(
+            '[undo] write changed:',
+            before !== after,
+            before.length,
+            '→',
+            after.length
+          );
+
+          // remove the card file and row
+          const success = await this.plugin.reviewManager.cards.delete(
+            reviewCard.data.id
+          );
+
+          const { parent } = reviewCard.data;
+          console.log(
+            '[undo] parent id:',
+            parent,
+            'current:',
+            store.getState().currentItemId
+          );
+          if (parent) {
+            const key = ['item', parent, 'file-text'];
+            const q0 = queryClient.getQueryCache().find({ queryKey: key });
+            console.log(
+              '[undo] before:',
+              !!q0,
+              '| len:',
+              (q0?.state.data as string)?.length,
+              '| updatedAt:',
+              q0?.state.dataUpdatedAt,
+              '| observers:',
+              q0?.observers.length
+            );
+
+            await invalidateItemQuery(parent);
+
+            const q1 = queryClient.getQueryCache().find({ queryKey: key });
+            console.log(
+              '[undo] after:',
+              '| len:',
+              (q1?.state.data as string)?.length,
+              '| updatedAt:',
+              q1?.state.dataUpdatedAt,
+              '| stale:',
+              q1?.isStale()
+            );
+          }
+        },
+      });
+    }
+
     return result;
   };
 

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -448,7 +448,10 @@ export class Actions {
 
   undo = async () => {
     const actionEntry = this.undoStack.pop();
-    if (actionEntry === undefined) return;
+    if (actionEntry === undefined) {
+      new Notice(`Nothing to undo!`, SUCCESS_NOTICE_DURATION_MS);
+      return;
+    }
     // Emitted before the reversal runs, not after: the entry is already off the
     // stack, and an undo that throws partway would otherwise leave subscribers
     // reading an entry that is no longer there.

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -266,16 +266,45 @@ export class Actions {
   createSnippet = async (firstReview?: number) => {
     const editor = this.plugin.app.workspace.activeEditor?.editor;
     if (!editor) return null;
+
     const view =
       this.plugin.getActiveReviewView() ??
       this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
     if (!view) return null;
-    const result = await this.plugin.reviewManager.createSnippet(
+
+    const parentFile = view.file;
+    if (!parentFile) return null;
+
+    const snippet = await this.plugin.reviewManager.createSnippet(
       editor,
       view,
       firstReview
     );
-    return result;
+
+    if (snippet !== null) {
+      this.pushUndo({
+        item: snippet,
+        description: `creating snippet "${snippet.file.basename}"`,
+        undo: async () => {
+          const success = await this.plugin.reviewManager.snippets.delete(
+            snippet.data.id
+          );
+          if (!success) return;
+
+          this.plugin.reviewManager.snippets.offsetTracker.removeHighlight(
+            parentFile.path,
+            snippet.data.id
+          );
+
+          // trigger a re-paint so the highlight disappears
+          this.plugin.app.workspace.trigger(
+            'ir-highlights-changed',
+            parentFile.path
+          );
+        },
+      });
+    }
+    return snippet;
   };
 
   createCard = async () => {

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -16,6 +16,7 @@ import {
 } from './query-client';
 import {
   addSeenId,
+  removeSeenId,
   resetCurrentItem,
   resetTypesToReview,
   setTypesToReview,
@@ -216,6 +217,14 @@ export class Actions {
     const resetTime = getEndOfDay(this.plugin.settings.dayRolloverOffset);
     this.plugin.store.dispatch(addSeenId({ id: item.data.id, resetTime }));
 
+    this.pushUndo({
+      item,
+      description: `skipping "${item.file.basename}"`,
+      undo: () => {
+        this.plugin.store.dispatch(removeSeenId({ id: item.data.id }));
+        this.getNext();
+      },
+    });
     new Notice(
       `Skipping ${getContentSlice(item.file.basename, CONTENT_TITLE_SLICE_LENGTH + 5, true)} until next session`
     );

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -167,11 +167,33 @@ export class Actions {
   };
 
   gradeCard = async (card: ReviewCard, grade: Grade) => {
-    await this.plugin.reviewManager.reviewCard(card.data, grade);
-    new Notice(`Graded as: ${Rating[grade]}`);
-    if (card.data.dismissed) {
+    const reviewRowId = await this.plugin.reviewManager.reviewCard(
+      card.data,
+      grade
+    );
+    const wasDismissed = card.data.dismissed;
+    if (wasDismissed) {
       await this.unDismissItem(card);
     }
+
+    this.pushUndo({
+      item: card,
+      description: `grading "${card.file.basename}" ${Rating[grade]}`,
+      undo: async () => {
+        await this.plugin.reviewManager.cards.rollbackBeforeReview(
+          card.data,
+          reviewRowId
+        );
+        if (wasDismissed) {
+          await this.dismissItem(card);
+        }
+
+        await invalidateItemQuery(card.data.id);
+        this.getNext();
+      },
+    });
+
+    new Notice(`Graded as: ${Rating[grade]}`);
     this.getNext();
   };
 

--- a/src/lib/Actions.ts
+++ b/src/lib/Actions.ts
@@ -31,14 +31,26 @@ import {
 } from './types';
 import { getContentSlice, getEndOfDay } from './utils';
 
+export type ActionStackEntry = {
+  item: ReviewItem;
+  description: string;
+  undo: () => void | Promise<void>;
+};
+
 /**
  * Coordinates review operations with store and query cache updates
  */
 export class Actions {
   plugin: IncrementalReadingPlugin;
+  undoStack: ActionStackEntry[];
+  emitter;
+  subscribe;
 
   constructor(plugin: IncrementalReadingPlugin) {
     this.plugin = plugin;
+    this.undoStack = [];
+    this.emitter = this.createEmitter();
+    this.subscribe = this.emitter.subscribe;
   }
 
   /** Call this after reviewing, skipping, dismissing, or deleting an open item */
@@ -53,7 +65,8 @@ export class Actions {
 
   reviewArticle = async (article: ReviewArticle, nextInterval?: number) => {
     try {
-      await this.plugin.reviewManager.reviewArticle(
+      const beforeReview = { ...article.data };
+      const reviewId = await this.plugin.reviewManager.reviewArticle(
         article.data,
         Date.now(),
         nextInterval
@@ -69,6 +82,18 @@ export class Actions {
         );
       }
       this.getNext();
+      this.pushUndo({
+        item: article,
+        description: `reviewing "${article.file.basename}"`,
+        undo: async () => {
+          await this.plugin.reviewManager.articles.undoReview(
+            beforeReview,
+            reviewId
+          );
+          await invalidateItemQuery(article.data.id);
+          this.getNext();
+        },
+      });
     } catch (error) {
       console.error(error);
     }
@@ -223,5 +248,39 @@ export class Actions {
     } else if (cardsOnly && currentItem.data.type !== 'card') {
       this.getNext();
     }
+  };
+
+  createEmitter() {
+    const listeners = new Set<() => void>();
+    return {
+      subscribe(fn: () => void) {
+        listeners.add(fn);
+        return () => void listeners.delete(fn);
+      },
+      emit() {
+        listeners.forEach((fn) => fn());
+      },
+    };
+  }
+
+  /**
+   * Record an undoable action. Every push goes through here: the stack is a
+   * plain array subscribers cannot watch, so a push that skips the emit leaves
+   * the undo button showing the action before it.
+   */
+  pushUndo = (entry: ActionStackEntry) => {
+    this.undoStack.push(entry);
+    this.emitter.emit();
+  };
+
+  undo = async () => {
+    const actionEntry = this.undoStack.pop();
+    if (actionEntry === undefined) return;
+    // Emitted before the reversal runs, not after: the entry is already off the
+    // stack, and an undo that throws partway would otherwise leave subscribers
+    // reading an entry that is no longer there.
+    this.emitter.emit();
+    await actionEntry.undo();
+    new Notice(`Undid ${actionEntry.description}`, SUCCESS_NOTICE_DURATION_MS);
   };
 }

--- a/src/lib/ObsidianHelpers.ts
+++ b/src/lib/ObsidianHelpers.ts
@@ -279,6 +279,21 @@ export class ObsidianHelpers {
     return normalizePath(`${dir}/${fileName}`);
   }
 
+  static findEmbeds(app: App, parent: TFile, target: TFile) {
+    const { metadataCache } = app;
+    const embeds = metadataCache.getFileCache(parent)?.embeds;
+    if (!embeds) return null;
+    const match = embeds.find((embed) => {
+      const linkPath = metadataCache.getFirstLinkpathDest(
+        embed.link,
+        parent.path
+      )?.path;
+      console.log({ embed, linkPath, targetPath: target.path });
+      return linkPath === target.path;
+    });
+    return match ?? null;
+  }
+
   static isDuplicate(fileName: string, noteType: NoteType, app: App) {
     return !!app.vault.getAbstractFileByPath(
       this.getTargetPath(fileName, noteType)

--- a/src/lib/extensions/SnippetHighlightExtension.test.ts
+++ b/src/lib/extensions/SnippetHighlightExtension.test.ts
@@ -56,17 +56,49 @@ function makeReviewManager(filePath = FILE_PATH): FakeReviewManager {
   };
 }
 
+type FakeEventRef = { name: string; callback: (...args: unknown[]) => unknown };
+
 type FakePlugin = {
   reviewManager: FakeReviewManager | null;
-  app: { workspace: { openLinkText: ReturnType<typeof vi.fn> } };
+  app: {
+    workspace: {
+      openLinkText: ReturnType<typeof vi.fn>;
+      on: ReturnType<typeof vi.fn>;
+      offref: ReturnType<typeof vi.fn>;
+      /** Drive the handlers registered via `on`, as Obsidian's trigger does. */
+      trigger: (name: string, ...args: unknown[]) => void;
+    };
+  };
 };
 
+/**
+ * The plugin subscribes to 'ir-highlights-changed' in its constructor, so
+ * on/offref must exist on every fake — a missing one throws there, and
+ * CodeMirror responds by dropping the ViewPlugin entirely.
+ */
 function makePlugin(
   reviewManager: FakeReviewManager | null = null
 ): FakePlugin {
+  const handlers = new Map<string, Set<(...args: unknown[]) => unknown>>();
   return {
     reviewManager,
-    app: { workspace: { openLinkText: vi.fn() } },
+    app: {
+      workspace: {
+        openLinkText: vi.fn(),
+        on: vi.fn((name: string, callback: (...args: unknown[]) => unknown) => {
+          const forName = handlers.get(name) ?? new Set();
+          forName.add(callback);
+          handlers.set(name, forName);
+          return { name, callback } satisfies FakeEventRef;
+        }),
+        offref: vi.fn((ref: FakeEventRef) => {
+          handlers.get(ref.name)?.delete(ref.callback);
+        }),
+        trigger: (name: string, ...args: unknown[]) => {
+          handlers.get(name)?.forEach((callback) => callback(...args));
+        },
+      },
+    },
   };
 }
 
@@ -756,11 +788,7 @@ describe('click event handler', () => {
   });
 
   it('does not throw when highlight span with data-snippet-ref is clicked', () => {
-    const openLinkText = vi.fn();
-    const irPlugin: FakePlugin = {
-      reviewManager: makeReviewManager(),
-      app: { workspace: { openLinkText } },
-    };
+    const irPlugin = makePlugin(makeReviewManager());
     const view = makeView('hello', irPlugin);
     const span = document.createElement('span');
     span.className = 'ir-snippet-highlight';
@@ -1268,5 +1296,55 @@ describe('mutant-killing: absoluteEnd boundary check (> vs >=)', () => {
     const plugin = view.plugin(snippetHighlightExtension);
     expect(plugin!.decorations.size).toBe(0);
     view.destroy();
+  });
+});
+
+describe('ir-highlights-changed subscription', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  /** A view with one highlight already painted for FILE_PATH. */
+  function makePaintedView() {
+    const rm = makeReviewManager();
+    rm.snippets.offsetTracker.loadHighlights(FILE_PATH, [makeHighlight()]);
+    const irPlugin = makePlugin(rm);
+    stubFileInfo(FILE_PATH, 'article');
+    // Never resolves, so the constructor's load can't overwrite the tracker.
+    rm.getSnippetHighlights.mockReturnValue(new Promise(() => {}));
+    const view = makeView('hello world!!', irPlugin);
+    view.dispatch({ effects: refreshHighlightsEffect.of(null) });
+    return { view, irPlugin, rm };
+  }
+
+  it('repaints from the tracker when the event names the file it shows', () => {
+    const { view, irPlugin, rm } = makePaintedView();
+    expect(view.plugin(snippetHighlightExtension)!.decorations.size).toBe(1);
+
+    // What undoing a snippet creation does: drop the highlight, then announce it.
+    // The view must repaint itself — nothing dispatches into it directly.
+    rm.snippets.offsetTracker.removeHighlight(FILE_PATH, 'h1');
+    irPlugin.app.workspace.trigger('ir-highlights-changed', FILE_PATH);
+
+    expect(view.plugin(snippetHighlightExtension)!.decorations.size).toBe(0);
+    view.destroy();
+  });
+
+  it('ignores the event when it names a different file', () => {
+    const { view, irPlugin, rm } = makePaintedView();
+    rm.snippets.offsetTracker.removeHighlight(FILE_PATH, 'h1');
+    irPlugin.app.workspace.trigger('ir-highlights-changed', 'notes/other.md');
+    expect(view.plugin(snippetHighlightExtension)!.decorations.size).toBe(1);
+    view.destroy();
+  });
+
+  it('releases the subscription it created when destroyed', () => {
+    const { view, irPlugin } = makePaintedView();
+    const ref = irPlugin.app.workspace.on.mock.results[0].value as unknown;
+
+    view.destroy();
+
+    expect(irPlugin.app.workspace.offref).toHaveBeenCalledWith(ref);
+    expect(() =>
+      irPlugin.app.workspace.trigger('ir-highlights-changed', FILE_PATH)
+    ).not.toThrow();
   });
 });

--- a/src/lib/extensions/SnippetHighlightExtension.ts
+++ b/src/lib/extensions/SnippetHighlightExtension.ts
@@ -139,8 +139,9 @@ export const snippetHighlightExtension = ViewPlugin.fromClass(
         // Non-user changes include:
         //   - isExternalSync: IREditor's value prop update after React Query invalidation
         //   - Obsidian's cross-pane sync when the same file is open in multiple panes
-        // In both cases the ChangeSet represents a full replacement, not the actual
-        // edit, so we can't map positions from it.
+        // Neither ChangeSet describes the edit a user made here — the sync one is
+        // a diff against text that arrived already saved, and the cross-pane one
+        // is a full replacement — so we don't map positions from either.
         const hasUserEvent = update.transactions.some(
           (tr) =>
             tr.isUserEvent('input') ||

--- a/src/lib/extensions/SnippetHighlightExtension.ts
+++ b/src/lib/extensions/SnippetHighlightExtension.ts
@@ -1,7 +1,8 @@
+import IncrementalReadingPlugin from '#/main';
 import { Annotation, RangeSetBuilder, StateEffect } from '@codemirror/state';
 import type { DecorationSet, EditorView, ViewUpdate } from '@codemirror/view';
 import { Decoration, ViewPlugin } from '@codemirror/view';
-import { type TFile } from 'obsidian';
+import { EventRef, type TFile } from 'obsidian';
 import type ReviewManager from '../items/ReviewManager';
 import { ObsidianHelpers as Obsidian } from '../ObsidianHelpers';
 import type {
@@ -43,6 +44,8 @@ export const snippetHighlightExtension = ViewPlugin.fromClass(
     private isReviewInterface: boolean = false;
     // keep track of if the ViewPlugin was destroyed
     private destroyed: boolean = false;
+    private highlightsChangedRef: EventRef | null = null;
+    private plugin: IncrementalReadingPlugin | null = null;
 
     constructor(view: EditorView) {
       const { info } = Obsidian.getFileInfoFromState(view.state);
@@ -53,6 +56,16 @@ export const snippetHighlightExtension = ViewPlugin.fromClass(
       // More reliable than getActiveViewOfType, which reflects focus at a point
       // in time and can be wrong when the editor is rebuilt by a React effect.
       this.isReviewInterface = view.state.facet(isReviewInterfaceFacet);
+
+      this.plugin = view.state.facet(irPluginFacet);
+      this.highlightsChangedRef =
+        this.plugin?.app.workspace.on(
+          'ir-highlights-changed',
+          (...args: unknown[]) => {
+            if (args[0] !== this.file?.path) return;
+            view.dispatch({ effects: refreshHighlightsEffect.of(null) });
+          }
+        ) ?? null;
 
       // Load highlights asynchronously
       void this.loadHighlights(view);
@@ -294,6 +307,11 @@ export const snippetHighlightExtension = ViewPlugin.fromClass(
 
     destroy() {
       this.destroyed = true;
+      if (this.highlightsChangedRef) {
+        this.plugin?.app.workspace.offref(this.highlightsChangedRef);
+        this.highlightsChangedRef = null;
+      }
+
       if (this.persistTimeout) {
         clearTimeout(this.persistTimeout);
         this.persistTimeout = null;

--- a/src/lib/extensions/SnippetHighlightExtension.ts
+++ b/src/lib/extensions/SnippetHighlightExtension.ts
@@ -1,4 +1,4 @@
-import IncrementalReadingPlugin from '#/main';
+import type IncrementalReadingPlugin from '#/main';
 import { Annotation, RangeSetBuilder, StateEffect } from '@codemirror/state';
 import type { DecorationSet, EditorView, ViewUpdate } from '@codemirror/view';
 import { Decoration, ViewPlugin } from '@codemirror/view';

--- a/src/lib/items/ArticleManager.test.ts
+++ b/src/lib/items/ArticleManager.test.ts
@@ -76,6 +76,7 @@ function makeRepo(
     }),
     mutate: vi.fn().mockResolvedValue([[]]),
     _execSql: vi.fn(),
+    transaction: vi.fn(async (work: () => unknown) => work()),
     handleFileChange: vi.fn(),
     onDataChange: vi.fn(() => vi.fn()),
   } as unknown as SQLiteRepository;
@@ -142,6 +143,7 @@ function makeSimpleRepo(): SQLiteRepository {
     query: vi.fn().mockResolvedValue([]),
     mutate: vi.fn().mockResolvedValue([[]]),
     _execSql: vi.fn(),
+    transaction: vi.fn(async (work: () => unknown) => work()),
     handleFileChange: vi.fn(),
     onDataChange: vi.fn(() => vi.fn()),
   } as unknown as SQLiteRepository;
@@ -192,6 +194,7 @@ async function makeSqlJsRepo(): Promise<{
       return [[]];
     }),
     _execSql: vi.fn(),
+    transaction: vi.fn(async (work: () => unknown) => work()),
     handleFileChange: vi.fn(),
     onDataChange: vi.fn(() => vi.fn()),
   } as unknown as SQLiteRepository;
@@ -381,6 +384,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -510,6 +514,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -538,6 +543,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -567,6 +573,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -613,6 +620,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -632,6 +640,7 @@ describe('getDue', () => {
       query: vi.fn().mockRejectedValue(new Error('db error')),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -965,6 +974,7 @@ describe('fetchMany', () => {
       query: vi.fn().mockResolvedValue(rows),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1127,6 +1137,7 @@ describe('fetch', () => {
       query: vi.fn().mockResolvedValue([]),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1143,6 +1154,7 @@ describe('fetch', () => {
           query: vi.fn().mockResolvedValue([]),
           mutate: vi.fn(),
           _execSql: vi.fn(),
+          transaction: vi.fn(async (work: () => unknown) => work()),
           handleFileChange: vi.fn(),
           onDataChange: vi.fn(() => vi.fn()),
         } as unknown as SQLiteRepository;
@@ -1163,6 +1175,7 @@ describe('fetch', () => {
       query: vi.fn().mockResolvedValue([row]),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1426,6 +1439,7 @@ describe('rename', () => {
       query: vi.fn().mockResolvedValue([]),
       mutate: vi.fn().mockRejectedValue(new Error('db error')),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1756,6 +1770,7 @@ describe('getDue (filter correctness)', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1805,6 +1820,7 @@ describe('getDue (filter correctness)', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1922,6 +1938,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1945,6 +1962,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1972,6 +1990,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1997,6 +2016,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -2021,6 +2041,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;

--- a/src/lib/items/ArticleManager.ts
+++ b/src/lib/items/ArticleManager.ts
@@ -561,6 +561,35 @@ export class ArticleManager extends ItemManager {
   }
 
   /**
+   * Reset the article and remove all reviews from the specified one onwards
+   */
+  async undoReview(originalArticle: IArticleBase, reviewId: string) {
+    await this.repo.transaction(async () => {
+      const reviewRow = (
+        await this.repo.query(`SELECT * FROM article_review WHERE id = $1`, [
+          reviewId,
+        ])
+      )[0] as IArticleReview;
+      if (!reviewRow)
+        throw new Error(`No article review found with ID "${reviewId}"`);
+      await this.repo.mutate(
+        `DELETE FROM article_review WHERE article_id = $1 AND (id = $2 OR review_time > $3`,
+        [originalArticle.id, reviewId, reviewRow.review_time]
+      );
+      await this.repo.mutate(
+        `UPDATE article SET dismissed = $1, due = $2, interval = $3, due_fuzz = $4 WHERE id = $5`,
+        [
+          originalArticle.dismissed,
+          originalArticle.due,
+          originalArticle.interval,
+          originalArticle.due_fuzz,
+          originalArticle.id,
+        ]
+      );
+    });
+  }
+
+  /**
    * @param newName The basename excluding the file extension
    */
   async rename(article: ReviewArticle, newName: string) {

--- a/src/lib/items/ArticleManager.ts
+++ b/src/lib/items/ArticleManager.ts
@@ -528,8 +528,9 @@ export class ArticleManager extends ItemManager {
   }
 
   /**
-   * Add a ArticleReview and update the due date and interval
-   * TODO: combine the operations into a transaction
+   * Add an ArticleReview and update the due date and interval in a transaction.
+   * @returns the id of the inserted `article_review` row
+   * @throws if either write fails, leaving the db unchanged
    */
   async review(
     article: IArticleBase,
@@ -543,21 +544,20 @@ export class ArticleManager extends ItemManager {
     const newFuzz = this.plugin.settings.fuzzTextReviews
       ? IRScheduler.getDueFuzz()
       : article.due_fuzz;
+    const reviewId = crypto.randomUUID();
 
-    try {
-      await Promise.all([
-        this.repo.mutate(
-          'INSERT INTO article_review (id, article_id, review_time) VALUES ($1, $2, $3)',
-          [crypto.randomUUID(), article.id, reviewed]
-        ),
-        this.repo.mutate(
-          `UPDATE article SET dismissed = 0, due = $1, interval = $2, due_fuzz = $3 WHERE id = $4`,
-          [nextDueTime, nextInterval, newFuzz, article.id]
-        ),
-      ]);
-    } catch (error) {
-      console.error(error);
-    }
+    await this.repo.transaction(async () => {
+      await this.repo.mutate(
+        'INSERT INTO article_review (id, article_id, review_time) VALUES ($1, $2, $3)',
+        [reviewId, article.id, reviewed]
+      );
+      await this.repo.mutate(
+        `UPDATE article SET dismissed = 0, due = $1, interval = $2, due_fuzz = $3 WHERE id = $4`,
+        [nextDueTime, nextInterval, newFuzz, article.id]
+      );
+    });
+
+    return reviewId;
   }
 
   /**

--- a/src/lib/items/CardManager.test.ts
+++ b/src/lib/items/CardManager.test.ts
@@ -39,6 +39,7 @@ function makeRepo(): SQLiteRepository {
     query: vi.fn().mockResolvedValue([]),
     mutate: vi.fn().mockResolvedValue([[]]),
     _execSql: vi.fn(),
+    transaction: vi.fn(async (work: () => unknown) => work()),
     handleFileChange: vi.fn(),
     onDataChange: vi.fn(() => vi.fn()),
   } as unknown as SQLiteRepository;
@@ -815,6 +816,7 @@ describe('fetchMany', () => {
       query: vi.fn().mockResolvedValue(rows),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -977,6 +979,7 @@ describe('fetch', () => {
       query: vi.fn().mockResolvedValue([row]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1012,6 +1015,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1065,6 +1069,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1082,6 +1087,7 @@ describe('getDue', () => {
       query: vi.fn().mockRejectedValue(new Error('db error')),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1099,6 +1105,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1135,6 +1142,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1173,6 +1181,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1201,6 +1210,7 @@ describe('review', () => {
             query: vi.fn().mockResolvedValue([storedRow]),
             mutate: vi.fn().mockResolvedValue([[]]),
             _execSql: vi.fn(),
+            transaction: vi.fn(async (work: () => unknown) => work()),
             handleFileChange: vi.fn(),
             onDataChange: vi.fn(() => vi.fn()),
           } as unknown as SQLiteRepository;
@@ -1248,6 +1258,7 @@ describe('review', () => {
             query: vi.fn().mockResolvedValue([storedRow]),
             mutate: vi.fn().mockResolvedValue([[]]),
             _execSql: vi.fn(),
+            transaction: vi.fn(async (work: () => unknown) => work()),
             handleFileChange: vi.fn(),
             onDataChange: vi.fn(() => vi.fn()),
           } as unknown as SQLiteRepository;
@@ -1301,6 +1312,7 @@ describe('review', () => {
       query: vi.fn().mockResolvedValue([storedRow]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1316,21 +1328,22 @@ describe('review', () => {
     expect(params[7]).toBe(priorLapses + 1);
   });
 
-  it('logs the error and does not throw when the stored card is not found', async () => {
+  it('throws without writing when the stored card is not found', async () => {
     const card = makeCardDisplay();
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const repo = {
       query: vi.fn().mockResolvedValue([]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
     const manager = new CardManager(makePlugin(), repo);
-    await expect(
-      manager.review(card, Rating.Good, new Date())
-    ).resolves.not.toThrow();
-    expect(consoleSpy).toHaveBeenCalled();
+    // The caller records an undo entry only if this resolves, so a missing
+    // card must surface as a rejection rather than a silent no-op.
+    await expect(manager.review(card, Rating.Good, new Date())).rejects.toThrow(
+      `No card found with id ${card.id}`
+    );
     // When storedCard is not found, no UPDATE or INSERT should be issued
     const mutateCalls = (repo.mutate as ReturnType<typeof vi.fn>).mock.calls;
     expect(mutateCalls).toHaveLength(0);
@@ -1343,6 +1356,7 @@ describe('review', () => {
       query: vi.fn().mockResolvedValue([storedRow]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1381,6 +1395,7 @@ describe('review — FSRS settings', () => {
       query: vi.fn().mockResolvedValue([storedRow]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;

--- a/src/lib/items/CardManager.ts
+++ b/src/lib/items/CardManager.ts
@@ -493,15 +493,19 @@ export class CardManager extends ItemManager {
       }
     );
 
-    try {
-      const { nextCard, reviewLog } = recordLog;
-      const storedCard = (
-        await this.repo.query(`SELECT * FROM srs_card WHERE id = $1`, [card.id])
-      )[0] as SRSCardRow;
-      if (!storedCard) {
-        throw new Error(`No card found with id ${card.id}`);
-      }
+    const { nextCard, reviewLog } = recordLog;
+    const storedCard = (
+      await this.repo.query(`SELECT * FROM srs_card WHERE id = $1`, [card.id])
+    )[0] as SRSCardRow;
+    if (!storedCard) {
+      throw new Error(`No card found with id ${card.id}`);
+    }
 
+    const reviewRow = SRSCardReview.displayToRow(
+      new SRSCardReview(card.id, reviewLog)
+    );
+
+    await this.repo.transaction(async () => {
       const updatedCard = CardManager.baseToRow(nextCard);
       let updateQuery = `UPDATE srs_card SET `;
       const columnUpdateSegments = [
@@ -535,9 +539,6 @@ export class CardManager extends ItemManager {
         `rating, state) VALUES ` +
         `($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`;
 
-      const reviewRow = SRSCardReview.displayToRow(
-        new SRSCardReview(card.id, reviewLog)
-      );
       const insertParams = [
         reviewRow.id,
         reviewRow.card_id,
@@ -552,8 +553,8 @@ export class CardManager extends ItemManager {
         reviewRow.state,
       ];
       await this.repo.mutate(insertQuery, insertParams);
-    } catch (error) {
-      console.error(error);
-    }
+    });
+
+    return reviewRow.id;
   }
 }

--- a/src/lib/items/CardManager.ts
+++ b/src/lib/items/CardManager.ts
@@ -2,6 +2,7 @@ import type {
   ISRSCard,
   ISRSCardDisplay,
   ReviewCard,
+  SRSCardReviewRow,
   SRSCardRow,
 } from '#/lib/types';
 import type IncrementalReadingPlugin from '#/main';
@@ -187,17 +188,15 @@ export class CardManager extends ItemManager {
       this.app
     );
     const selectionBounds = Obsidian.getSelectionWithBounds(editor);
-    const bounds = selectionBounds
-      ? ([
-          selectionBounds.start.ch - start,
-          selectionBounds.end.ch - start,
-        ] as const)
-      : null;
-
-    if (!bounds) {
+    if (!selectionBounds) {
       new Notice('Text must be selected', ERROR_NOTICE_DURATION_MS);
       return;
     }
+
+    const bounds = [
+      selectionBounds.start.ch - start,
+      selectionBounds.end.ch - start,
+    ] as const;
 
     try {
       const withDelimiters = this.delimitText(line, bounds)[0];
@@ -221,7 +220,13 @@ export class CardManager extends ItemManager {
       );
       // move the cursor to the next block
       editor.setSelection({ line: lineNumber + 1, ch: 0 });
-      return reviewCard;
+      return {
+        reviewCard,
+        line,
+        lineNumber,
+        start,
+        end,
+      };
     } catch (error) {
       if (error instanceof Error) {
         console.error(error);
@@ -299,6 +304,29 @@ export class CardManager extends ItemManager {
     }
   }
 
+  /**
+   * Drop a card's row and delete its note
+   */
+  async delete(id: string) {
+    try {
+      const row = (
+        await this.repo.query(`SELECT * FROM srs_card WHERE id = $1`, [id])
+      )[0] as SRSCardRow | null;
+      if (!row) throw new Error(`No card was found with ID "${id}"`);
+
+      const file = Obsidian.getNote(row.reference, this.app);
+      if (file) {
+        // delete the card file
+        await this.plugin.app.fileManager.promptForFileDeletion(file);
+      }
+
+      // remove the row entirely
+      await this.repo.mutate(`DELETE FROM srs_card WHERE id = $1`, [id]);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
   /**
    * If text is selected, adds cloze deletion delimiters around the selection
    * and removes them elsewhere.

--- a/src/lib/items/CardManager.ts
+++ b/src/lib/items/CardManager.ts
@@ -557,4 +557,54 @@ export class CardManager extends ItemManager {
 
     return reviewRow.id;
   }
+
+  async rollbackBeforeReview(card: ISRSCardDisplay, reviewRowId: string) {
+    const reviewRow = (
+      await this.repo.query(
+        `SELECT * FROM srs_card_review WHERE id = $1 AND card_id = $2`,
+        [reviewRowId, card.id]
+      )
+    )[0] as SRSCardReviewRow | undefined;
+    if (!reviewRow) {
+      throw new Error(
+        `No card review found with id ${reviewRowId} for card ${card.id}`
+      );
+    }
+
+    const rolledBackCard = this.getFsrs().rollback(card, reviewRow);
+    await this.repo.transaction(async () => {
+      // update the card row
+      const updatedCard = CardManager.baseToRow({ ...card, ...rolledBackCard });
+      let updateQuery = `UPDATE srs_card SET `;
+      const columnUpdateSegments = [
+        `due = $1, last_review = $2`,
+        `stability = $3, difficulty = $4`,
+        `elapsed_days = $5`,
+        `scheduled_days = $6`,
+        `reps = $7, lapses = $8`,
+        `state = $9, dismissed = 0`,
+      ];
+      updateQuery += columnUpdateSegments.join(', ');
+      updateQuery += ` WHERE id = $10`;
+      const updateParams = [
+        updatedCard.due,
+        updatedCard.last_review,
+        updatedCard.stability,
+        updatedCard.difficulty,
+        updatedCard.elapsed_days,
+        updatedCard.scheduled_days,
+        updatedCard.reps,
+        updatedCard.lapses,
+        updatedCard.state,
+        card.id,
+      ];
+      await this.repo.mutate(updateQuery, updateParams);
+
+      // delete the specified review and all following reviews for this card
+      await this.repo.mutate(
+        `DELETE FROM srs_card_review WHERE card_id = $1 AND review >= $2`,
+        [card.id, reviewRow.review]
+      );
+    });
+  }
 }

--- a/src/lib/items/SnippetManager.test.ts
+++ b/src/lib/items/SnippetManager.test.ts
@@ -66,6 +66,7 @@ function makeSimpleRepo(): SQLiteRepository {
     query: vi.fn().mockResolvedValue([]),
     mutate: vi.fn().mockResolvedValue([[]]),
     _execSql: vi.fn(),
+    transaction: vi.fn(async (work: () => unknown) => work()),
     handleFileChange: vi.fn(),
     onDataChange: vi.fn(() => vi.fn()),
   } as unknown as SQLiteRepository;
@@ -83,6 +84,7 @@ function makeRepoWithLastReview(
     }),
     mutate: vi.fn().mockResolvedValue([[]]),
     _execSql: vi.fn(),
+    transaction: vi.fn(async (work: () => unknown) => work()),
     handleFileChange: vi.fn(),
     onDataChange: vi.fn(() => vi.fn()),
   } as unknown as SQLiteRepository;
@@ -168,6 +170,7 @@ async function makeSqlJsRepo(): Promise<{
       return [[]];
     }),
     _execSql: vi.fn(),
+    transaction: vi.fn(async (work: () => unknown) => work()),
     handleFileChange: vi.fn(),
     onDataChange: vi.fn(() => vi.fn()),
   } as unknown as SQLiteRepository;
@@ -562,6 +565,7 @@ describe('fetchMany', () => {
       query: vi.fn().mockResolvedValue(rows),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -720,6 +724,7 @@ describe('fetch', () => {
       query: vi.fn().mockResolvedValue([]),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -736,6 +741,7 @@ describe('fetch', () => {
           query: vi.fn().mockResolvedValue([]),
           mutate: vi.fn(),
           _execSql: vi.fn(),
+          transaction: vi.fn(async (work: () => unknown) => work()),
           handleFileChange: vi.fn(),
           onDataChange: vi.fn(() => vi.fn()),
         } as unknown as SQLiteRepository;
@@ -756,6 +762,7 @@ describe('fetch', () => {
       query: vi.fn().mockResolvedValue([row]),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -799,6 +806,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -888,6 +896,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -917,6 +926,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -944,6 +954,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -986,6 +997,7 @@ describe('getDue', () => {
       }),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1005,6 +1017,7 @@ describe('getDue', () => {
       query: vi.fn().mockRejectedValue(new Error('db error')),
       mutate: vi.fn(),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1106,11 +1119,12 @@ describe('review', () => {
     );
   });
 
-  it('does not throw when the repo mutate rejects', async () => {
+  it('propagates the error when the repo mutate rejects', async () => {
     const repo = {
       query: vi.fn().mockResolvedValue([]),
       mutate: vi.fn().mockRejectedValue(new Error('db error')),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1118,7 +1132,9 @@ describe('review', () => {
       { settings: { fuzzReviewTimes: false } } as never,
       repo
     );
-    await expect(manager.review(makeSnippet(), 1)).resolves.toBeUndefined();
+    // A swallowed failure would leave the caller recording an undo entry for a
+    // review the database never accepted.
+    await expect(manager.review(makeSnippet(), 1)).rejects.toThrow('db error');
   });
 
   it('uses a provided nextReviewInterval instead of computing one', async () => {
@@ -1247,6 +1263,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1270,6 +1287,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1295,6 +1313,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1319,6 +1338,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;
@@ -1343,6 +1363,7 @@ describe('fuzzing (getDue sort)', () => {
       query: vi.fn().mockResolvedValue([rowA, rowB]),
       mutate: vi.fn().mockResolvedValue([[]]),
       _execSql: vi.fn(),
+      transaction: vi.fn(async (work: () => unknown) => work()),
       handleFileChange: vi.fn(),
       onDataChange: vi.fn(() => vi.fn()),
     } as unknown as SQLiteRepository;

--- a/src/lib/items/SnippetManager.ts
+++ b/src/lib/items/SnippetManager.ts
@@ -619,6 +619,34 @@ export class SnippetManager extends ItemManager {
   }
 
   /**
+   * Reset the snippet and remove all reviews from the specified one onwards
+   */
+  async undoReview(originalSnippet: ISnippetBase, reviewId: string) {
+    await this.repo.transaction(async () => {
+      const reviewRow = (
+        await this.repo.query(`SELECT * FROM snippet_review WHERE id = $1`, [
+          reviewId,
+        ])
+      )[0] as ISnippetReview;
+      if (!reviewRow)
+        throw new Error(`No snippet review found with ID "${reviewId}"`);
+      await this.repo.mutate(
+        `DELETE FROM snippet_review WHERE snippet_id = $1 AND (id = $2 OR review_time > $3)`,
+        [originalSnippet.id, reviewId, reviewRow.review_time]
+      );
+      await this.repo.mutate(
+        `UPDATE snippet SET dismissed = $1, due = $2, interval = $3, due_fuzz = $4 WHERE id = $5`,
+        [
+          originalSnippet.dismissed,
+          originalSnippet.due,
+          originalSnippet.interval,
+          originalSnippet.due_fuzz,
+          originalSnippet.id,
+        ]
+      );
+    });
+  }
+  /**
    * Change the priority of a snippet and recalculate its next due date
    */
   async reprioritize(snippet: ISnippetBase, newPriority: number) {

--- a/src/lib/items/SnippetManager.ts
+++ b/src/lib/items/SnippetManager.ts
@@ -462,7 +462,7 @@ export class SnippetManager extends ItemManager {
     // For articles/snippets with a DB entry, use the existing parent ID query
     if (parentEntry) {
       const results = (await this.repo.query(
-        'SELECT * FROM snippet WHERE parent = $1 AND start_offset IS NOT NULL AND end_offset IS NOT NULL',
+        'SELECT * FROM snippet WHERE parent = $1 AND start_offset IS NOT NULL AND end_offset IS NOT NULL AND deleted = FALSE',
         [parentEntry.id]
       )) as SnippetRow[];
 

--- a/src/lib/items/SnippetManager.ts
+++ b/src/lib/items/SnippetManager.ts
@@ -586,8 +586,9 @@ export class SnippetManager extends ItemManager {
   }
 
   /**
-   * Add a SnippetReview and update the due date and interval
-   * TODO: combine the operations into a transaction
+   * Add a SnippetReview and update the due date and interval in a transaction.
+   * @returns the id of the inserted `snippet_review` row
+   * @throws if either write fails, leaving the db unchanged
    */
   async review(
     snippet: ISnippetBase,
@@ -601,21 +602,20 @@ export class SnippetManager extends ItemManager {
     const newFuzz = this.plugin.settings.fuzzTextReviews
       ? IRScheduler.getDueFuzz()
       : snippet.due_fuzz;
+    const reviewId = crypto.randomUUID();
 
-    try {
-      await Promise.all([
-        this.repo.mutate(
-          'INSERT INTO snippet_review (id, snippet_id, review_time) VALUES ($1, $2, $3)',
-          [crypto.randomUUID(), snippet.id, reviewed]
-        ),
-        this.repo.mutate(
-          `UPDATE snippet SET dismissed = 0, due = $1, interval = $2, due_fuzz = $3 WHERE id = $4`,
-          [nextDueTime, nextInterval, newFuzz, snippet.id]
-        ),
-      ]);
-    } catch (error) {
-      console.error(error);
-    }
+    await this.repo.transaction(async () => {
+      await this.repo.mutate(
+        'INSERT INTO snippet_review (id, snippet_id, review_time) VALUES ($1, $2, $3)',
+        [reviewId, snippet.id, reviewed]
+      );
+      await this.repo.mutate(
+        `UPDATE snippet SET dismissed = 0, due = $1, interval = $2, due_fuzz = $3 WHERE id = $4`,
+        [nextDueTime, nextInterval, newFuzz, snippet.id]
+      );
+    });
+
+    return reviewId;
   }
 
   /**

--- a/src/lib/items/SnippetManager.ts
+++ b/src/lib/items/SnippetManager.ts
@@ -382,6 +382,31 @@ export class SnippetManager extends ItemManager {
     }
   }
 
+  /**
+   * Delete snippet file and mark row as deleted.
+   */
+  async delete(id: string) {
+    try {
+      const row = (
+        await this.repo.query(`SELECT * FROM snippet WHERE id = $1`, [id])
+      )[0] as SnippetRow | null;
+      if (!row) throw new Error(`No snippet was found with ID "${id}"`);
+
+      const file = Obsidian.getNote(row.reference, this.app);
+      if (file) {
+        // delete the snippet file
+        await this.plugin.app.fileManager.promptForFileDeletion(file);
+      }
+
+      // remove the row entirely
+      await this.repo.mutate(`DELETE FROM snippet WHERE id = $1`, [id]);
+
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   async fetch(id: string): Promise<ReviewSnippet | null> {
     const query = `SELECT * FROM snippet WHERE id = $1`;
     const result = await this.repo.query(query, [id]);

--- a/src/lib/obsidian-editor.ts
+++ b/src/lib/obsidian-editor.ts
@@ -126,10 +126,15 @@ export function getVimPlugin(cm: EditorView): unknown {
   );
 }
 
+/**
+ * `getCurrentItem` is read on every access rather than captured: the item is
+ * refetched on an interval and can come back with a renamed file, and Obsidian
+ * resolves links and embeds against whatever `file`/`path` report at the time.
+ */
 export const getMarkdownController = (
   view: ReviewView,
   getEditor: () => Editor,
-  currentItem: ReviewItem
+  getCurrentItem: () => ReviewItem
 ) => {
   return {
     ...view,
@@ -149,10 +154,10 @@ export const getMarkdownController = (
       return getEditor();
     },
     get file() {
-      return currentItem?.file;
+      return getCurrentItem()?.file;
     },
     get path() {
-      return currentItem?.file.path;
+      return getCurrentItem()?.file.path;
     },
   };
 };

--- a/src/lib/repository/SQLJSRepository.test.ts
+++ b/src/lib/repository/SQLJSRepository.test.ts
@@ -1,8 +1,9 @@
 import type { DataChangeEvent } from '#/lib/types';
+import fc from 'fast-check';
 import { readFileSync } from 'fs';
-import type { App } from 'obsidian';
+import type { App, TAbstractFile } from 'obsidian';
 import { resolve } from 'path';
-import type { Database } from 'sql.js';
+import type { Database, SqlValue } from 'sql.js';
 import initSqlJs from 'sql.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SQLJSRepository } from './SQLJSRepository';
@@ -108,6 +109,183 @@ function insertCard(repo: TestRepository, id: string) {
     [id, `cards/${id}.md`, Date.now(), Date.now()]
   );
 }
+
+// --- Obsidian Sync simulation ---
+
+const SYNCED_DB_PATH = 'ir-sync-test.sqlite';
+/** Fixed so two generated databases differ only in which rows they hold. */
+const FIXED_DUE = 1_700_000_000_000;
+
+const INSERT_ARTICLE_SQL = `INSERT INTO article (id, reference, due, interval, priority)
+   VALUES ($1, $2, $3, $4, $5)`;
+
+let sharedSql: Promise<initSqlJs.SqlJsStatic> | null = null;
+let sharedSchema: string | null = null;
+
+/**
+ * Initializing the WASM module and reading the schema dominate the cost of
+ * building a database, and the property below builds several per run — share
+ * one of each rather than paying for them thousands of times.
+ */
+function getSharedSql(): Promise<initSqlJs.SqlJsStatic> {
+  return (sharedSql ??= makeSql());
+}
+
+function getSharedSchema(): string {
+  return (sharedSchema ??= loadSchema());
+}
+
+function articleRow(id: string): (string | number)[] {
+  return [id, `articles/${id}.md`, FIXED_DUE, 86_400_000, 30];
+}
+
+function insertArticleRow(repo: SQLJSRepository, id: string) {
+  repo.mutate(INSERT_ARTICLE_SQL, articleRow(id));
+}
+
+/** Ids of every article row the repository can currently see. */
+function articleIds(repo: SQLJSRepository): string[] {
+  return (repo.query('SELECT id FROM article') as { id: string }[]).map(
+    (row) => row.id
+  );
+}
+
+const remoteDbCache = new Map<string, Uint8Array>();
+
+/**
+ * Serialized bytes of a database holding exactly `ids` — what another device's
+ * copy of the file looks like once Obsidian Sync brings it down.
+ */
+async function remoteDbBytes(ids: readonly string[]): Promise<Uint8Array> {
+  const key = ids.join(',');
+  const cached = remoteDbCache.get(key);
+  if (cached) return cached;
+
+  const SQL = await getSharedSql();
+  const db = new SQL.Database();
+  db.exec(getSharedSchema());
+  for (const id of ids)
+    db.exec(INSERT_ARTICLE_SQL, articleRow(id) as SqlValue[]);
+  const bytes = db.export();
+  db.close();
+  remoteDbCache.set(key, bytes);
+  return bytes;
+}
+
+/**
+ * A repository whose database file sits on a fake disk that a second writer —
+ * Obsidian Sync — can overwrite at any moment. `save`, `reloadDb` and
+ * `handleFileChange` are the production implementations; only the WASM loader
+ * and the vault adapter are stubbed, so a reload really does swap `this.db`
+ * for a fresh instance built from whatever bytes are on disk.
+ *
+ * `readBinary` parks until {@link SyncedTestRepository.landSync} releases it.
+ * That is what makes the interleaving controllable, and it is faithful: in
+ * production the reload suspends there too, for however long it takes to read
+ * the file — which on a synced vault is long enough for a review to start and
+ * finish in the meantime.
+ */
+class SyncedTestRepository extends SQLJSRepository {
+  /** Bytes on "disk". Sync overwrites these behind the plugin's back. */
+  diskBytes: Uint8Array = new Uint8Array();
+  /** Writes a still-open transaction could not read back, if any. */
+  readBackFailures: string[] = [];
+  #parkedReads: Array<() => void> = [];
+  #inFlightSync: Promise<void> | null = null;
+  #sqlStatic!: initSqlJs.SqlJsStatic;
+
+  static async create(): Promise<SyncedTestRepository> {
+    const SQL = await getSharedSql();
+    const schema = getSharedSchema();
+    let repo!: SyncedTestRepository;
+    const adapter = {
+      writeBinary: async (_path: string, data: ArrayBuffer) => {
+        repo.diskBytes = new Uint8Array(data.slice(0));
+      },
+      // Resolves against whatever is on disk when the read lands rather than
+      // when it was issued, so a save that beats the read wins — as it would
+      // on a real filesystem.
+      readBinary: async (_path: string) => {
+        await new Promise<void>((release) => repo.#parkedReads.push(release));
+        return repo.diskBytes.slice().buffer;
+      },
+    };
+    repo = new SyncedTestRepository({
+      app: {
+        vault: { adapter, getFolderByPath: () => ({}) },
+      } as unknown as App,
+      dbFilePath: SYNCED_DB_PATH,
+      schema,
+    });
+    repo.#sqlStatic = SQL;
+    repo.db = new SQL.Database();
+    repo.db.exec(schema);
+    repo.registerUpdateHook();
+    await repo.save(); // seed the file, so a reload always finds a valid db
+    return repo;
+  }
+
+  protected override async loadWasm() {
+    return this.#sqlStatic;
+  }
+
+  /**
+   * Close the database the reload just replaced. Production leaks it, which is
+   * harmless there but would pile thousands up over a fuzz run. Nothing reads
+   * the old instance either way.
+   */
+  protected override async reloadDb() {
+    const previous = this.db;
+    const result = await super.reloadDb();
+    if (this.db !== previous) previous?.close();
+    return result;
+  }
+
+  /** Sync writes a peer's copy of the file; Obsidian fires `modify` for it. */
+  beginSync(bytes: Uint8Array) {
+    this.diskBytes = bytes;
+    this.#inFlightSync = this.handleFileChange({
+      path: SYNCED_DB_PATH,
+    } as TAbstractFile);
+  }
+
+  /** Release the parked read so the reload it belongs to runs to completion. */
+  async landSync(): Promise<void> {
+    // The reload awaits the WASM loader before it reads the file; let those
+    // microtasks drain so the read is really parked before releasing it.
+    for (let i = 0; this.#parkedReads.length === 0 && i < 20; i++) {
+      await Promise.resolve();
+    }
+    this.#parkedReads.shift()?.();
+    await this.#inFlightSync;
+    this.#inFlightSync = null;
+  }
+
+  /** Finish a reload still in flight, so a run ends in a settled state. */
+  async settleSync(): Promise<void> {
+    if (this.#inFlightSync) await this.landSync();
+  }
+
+  /**
+   * Wait out the floating `save()` a non-transactional `mutate` starts. Until
+   * it settles `pendingSaveCount` is non-zero, which makes `handleFileChange`
+   * ignore an incoming sync.
+   */
+  async settleSaves(): Promise<void> {
+    for (let i = 0; this.pendingSaveCount > 0 && i < 20; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  /** Ids a fresh reader would find in the file on disk. */
+  async articleIdsOnDisk(): Promise<string[]> {
+    const SQL = await getSharedSql();
+    const db = new SQL.Database(this.diskBytes);
+    const result = db.exec('SELECT id FROM article');
+    db.close();
+    return (result[0]?.values ?? []).map((row) => row[0] as string);
+  }
+}
 // #endregion
 
 describe('onDataChange', () => {
@@ -127,9 +305,7 @@ describe('onDataChange', () => {
 
     insertArticle(repo, 'a1');
 
-    expect(events).toEqual([
-      { table: 'article', op: 'insert', ids: ['a1'] },
-    ]);
+    expect(events).toEqual([{ table: 'article', op: 'insert', ids: ['a1'] }]);
   });
 
   it('emits an update event with the affected id', () => {
@@ -139,9 +315,7 @@ describe('onDataChange', () => {
 
     repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [40, 'a1']);
 
-    expect(events).toEqual([
-      { table: 'article', op: 'update', ids: ['a1'] },
-    ]);
+    expect(events).toEqual([{ table: 'article', op: 'update', ids: ['a1'] }]);
   });
 
   it('emits an update event when a row is soft-deleted', () => {
@@ -153,9 +327,7 @@ describe('onDataChange', () => {
 
     repo.mutate(`UPDATE article SET deleted = TRUE WHERE id = $1`, ['a1']);
 
-    expect(events).toEqual([
-      { table: 'article', op: 'update', ids: ['a1'] },
-    ]);
+    expect(events).toEqual([{ table: 'article', op: 'update', ids: ['a1'] }]);
   });
 
   it('resolves ids for writes that match on a non-id column', () => {
@@ -168,9 +340,7 @@ describe('onDataChange', () => {
       'articles/a1.md',
     ]);
 
-    expect(events).toEqual([
-      { table: 'article', op: 'update', ids: ['a1'] },
-    ]);
+    expect(events).toEqual([{ table: 'article', op: 'update', ids: ['a1'] }]);
   });
 
   it('maps the srs_card table to the card note type', () => {
@@ -279,5 +449,542 @@ describe('onDataChange', () => {
       { table: 'article', op: 'update', ids: ['a1'] },
       { table: 'article', op: 'insert', ids: ['a2'] },
     ]);
+  });
+});
+
+describe('mutate error propagation', () => {
+  let repo: TestRepository;
+
+  beforeEach(async () => {
+    ({ repo } = await makeRepo());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // A write that silently resolves to [] is indistinguishable from one that
+  // returned no rows, so callers could record undo entries for writes the
+  // database rejected.
+  it('throws when a write violates a constraint', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    insertArticle(repo, 'a1');
+
+    expect(() => insertArticle(repo, 'a1')).toThrow();
+  });
+
+  it('throws on malformed SQL', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => repo.mutate('UPDATE nonexistent_table SET x = 1')).toThrow();
+  });
+
+  // Reads keep their empty-array fallback: many callers rely on it.
+  it('still resolves reads of a missing table to an empty result', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(repo.query('SELECT * FROM nonexistent_table')).toEqual([]);
+  });
+});
+
+describe('transaction', () => {
+  let repo: TestRepository;
+
+  beforeEach(async () => {
+    ({ repo } = await makeRepo());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('commits every write when the callback resolves', async () => {
+    await repo.transaction(async () => {
+      insertArticle(repo, 'a1', 30);
+      repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [40, 'a1']);
+    });
+
+    const rows = repo.query('SELECT priority FROM article WHERE id = $1', [
+      'a1',
+    ]);
+    expect(rows).toEqual([{ priority: 40 }]);
+  });
+
+  it('returns the callback result', async () => {
+    const result = await repo.transaction(async () => 'done');
+
+    expect(result).toBe('done');
+  });
+
+  // The reason the review mutators are wrapped: a due date must never move
+  // without the review row that justifies it.
+  it('rolls back earlier writes when a later one fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    insertArticle(repo, 'a1', 30);
+
+    await expect(
+      repo.transaction(async () => {
+        repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [
+          40,
+          'a1',
+        ]);
+        repo.mutate('INSERT INTO nonexistent_table VALUES (1)');
+      })
+    ).rejects.toThrow();
+
+    const rows = repo.query('SELECT priority FROM article WHERE id = $1', [
+      'a1',
+    ]);
+    expect(rows).toEqual([{ priority: 30 }]);
+  });
+
+  it('rolls back when the callback throws without any failed statement', async () => {
+    insertArticle(repo, 'a1', 30);
+
+    await expect(
+      repo.transaction(async () => {
+        repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [
+          40,
+          'a1',
+        ]);
+        throw new Error('caller aborted');
+      })
+    ).rejects.toThrow('caller aborted');
+
+    const rows = repo.query('SELECT priority FROM article WHERE id = $1', [
+      'a1',
+    ]);
+    expect(rows).toEqual([{ priority: 30 }]);
+  });
+
+  it('leaves the database writable after a rollback', async () => {
+    insertArticle(repo, 'a1', 30);
+    await expect(
+      repo.transaction(async () => {
+        throw new Error('aborted');
+      })
+    ).rejects.toThrow();
+
+    expect(() =>
+      repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [40, 'a1'])
+    ).not.toThrow();
+    expect(
+      repo.query('SELECT priority FROM article WHERE id = $1', ['a1'])
+    ).toEqual([{ priority: 40 }]);
+  });
+
+  // Subscribers refresh the queue from these events; a rolled-back row that
+  // emitted would leave the UI showing state the database never held.
+  it('emits no change events when the transaction rolls back', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const events: DataChangeEvent[] = [];
+    repo.onDataChange((e) => events.push(e));
+
+    await expect(
+      repo.transaction(async () => {
+        insertArticle(repo, 'a1');
+        repo.mutate('INSERT INTO nonexistent_table VALUES (1)');
+      })
+    ).rejects.toThrow();
+
+    expect(events).toEqual([]);
+  });
+
+  it('emits buffered change events once after commit', async () => {
+    const events: DataChangeEvent[] = [];
+    repo.onDataChange((e) => events.push(e));
+
+    await repo.transaction(async () => {
+      insertArticle(repo, 'a1');
+      insertArticle(repo, 'a2');
+    });
+
+    expect(events).toEqual([
+      { table: 'article', op: 'insert', ids: ['a1', 'a2'] },
+    ]);
+  });
+
+  // sql.js `save()` exports and rewrites the whole database file, so doing it
+  // per statement inside a transaction would also serialize uncommitted state.
+  it('saves once per transaction rather than once per statement', async () => {
+    const { repo: savingRepo } = await makeSavingRepo();
+    const writeBinary = savingRepo.app.vault.adapter.writeBinary as ReturnType<
+      typeof vi.fn
+    >;
+
+    await savingRepo.transaction(async () => {
+      savingRepo.mutate(
+        `INSERT INTO article (id, reference, due, interval, priority)
+         VALUES ($1, $2, $3, $4, $5)`,
+        ['a1', 'articles/a1.md', Date.now(), 86_400_000, 30]
+      );
+      savingRepo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [
+        40,
+        'a1',
+      ]);
+    });
+
+    expect(writeBinary).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write to disk when the transaction rolls back', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { repo: savingRepo } = await makeSavingRepo();
+    const writeBinary = savingRepo.app.vault.adapter.writeBinary as ReturnType<
+      typeof vi.fn
+    >;
+
+    await expect(
+      savingRepo.transaction(async () => {
+        savingRepo.mutate(
+          `INSERT INTO article (id, reference, due, interval, priority)
+           VALUES ($1, $2, $3, $4, $5)`,
+          ['a1', 'articles/a1.md', Date.now(), 86_400_000, 30]
+        );
+        throw new Error('aborted');
+      })
+    ).rejects.toThrow();
+
+    expect(writeBinary).not.toHaveBeenCalled();
+  });
+
+  // SQLite has no nested transactions; an inner call joins the outer one so a
+  // failure cannot be committed around.
+  it('commits a nested transaction only with the outermost one', async () => {
+    insertArticle(repo, 'a1', 30);
+
+    await expect(
+      repo.transaction(async () => {
+        await repo.transaction(async () => {
+          repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [
+            40,
+            'a1',
+          ]);
+        });
+        throw new Error('outer aborted');
+      })
+    ).rejects.toThrow('outer aborted');
+
+    const rows = repo.query('SELECT priority FROM article WHERE id = $1', [
+      'a1',
+    ]);
+    expect(rows).toEqual([{ priority: 30 }]);
+  });
+
+  it('restores normal per-write behavior after a transaction commits', async () => {
+    const events: DataChangeEvent[] = [];
+    await repo.transaction(async () => {
+      insertArticle(repo, 'a1');
+    });
+    repo.onDataChange((e) => events.push(e));
+
+    repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [40, 'a1']);
+
+    expect(events).toEqual([{ table: 'article', op: 'update', ids: ['a1'] }]);
+  });
+});
+
+// On a vault with Obsidian Sync running, a second writer rewrites the database
+// file at arbitrary times. Obsidian reports that as a `modify` event, and
+// `handleFileChange` answers it by reloading — replacing `this.db` wholesale.
+//
+// `mutate` used to save after every statement, so `pendingSaveCount` was
+// non-zero for most of a write burst and the reload was usually suppressed.
+// Inside a transaction it no longer saves, so the count stays at zero from
+// BEGIN until COMMIT and nothing stands between an incoming reload and a
+// half-finished transaction.
+describe('external sync while a transaction is open', () => {
+  beforeEach(() => {
+    // A failed statement and a failed reload both log. Here those failures are
+    // the subject of the test, not noise worth printing.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Control: proves the harness really does swap the database out, so the
+  // failures below cannot be an artifact of the fake vault.
+  it('replaces the in-memory database when a sync lands outside a transaction', async () => {
+    const repo = await SyncedTestRepository.create();
+    insertArticleRow(repo, 'local-1');
+    await repo.settleSaves();
+
+    repo.beginSync(await remoteDbBytes(['remote-1']));
+    await repo.landSync();
+
+    expect(articleIds(repo)).toEqual(['remote-1']);
+  });
+
+  // The reason the review mutators are wrapped in a transaction at all: an
+  // article whose due date moved without the review row that justifies it has
+  // been rescheduled off a review that never happened.
+  it('commits every write when a sync reload lands between two of them', async () => {
+    const repo = await SyncedTestRepository.create();
+    const remote = await remoteDbBytes(['remote-1']);
+
+    await repo.transaction(async () => {
+      insertArticleRow(repo, 'local-1');
+      repo.beginSync(remote);
+      await repo.landSync();
+      insertArticleRow(repo, 'local-2');
+    });
+
+    expect(articleIds(repo)).toEqual(
+      expect.arrayContaining(['local-1', 'local-2'])
+    );
+  });
+
+  // Weaker than the above, and still required of any fix that answers a
+  // mid-transaction reload by failing the transaction instead of surviving it.
+  it('leaves no partial transaction behind when a sync reload lands mid-transaction', async () => {
+    const repo = await SyncedTestRepository.create();
+    const remote = await remoteDbBytes(['remote-1']);
+    let rejected = false;
+
+    await repo
+      .transaction(async () => {
+        insertArticleRow(repo, 'local-1');
+        repo.beginSync(remote);
+        await repo.landSync();
+        insertArticleRow(repo, 'local-2');
+      })
+      .catch(() => {
+        rejected = true;
+      });
+
+    const present = articleIds(repo);
+    const applied = ['local-1', 'local-2'].filter((id) => present.includes(id));
+    expect(applied).toEqual(rejected ? [] : ['local-1', 'local-2']);
+  });
+
+  // A transaction saves once, after COMMIT. If the reload derails it before
+  // then, the writes live only in memory and the next reload erases them.
+  it('persists a committed transaction whose writes all follow a sync reload', async () => {
+    const repo = await SyncedTestRepository.create();
+    const remote = await remoteDbBytes(['remote-1']);
+
+    await repo.transaction(async () => {
+      repo.beginSync(remote);
+      await repo.landSync();
+      insertArticleRow(repo, 'local-1');
+    });
+
+    expect(await repo.articleIdsOnDisk()).toContain('local-1');
+  });
+
+  // The caller decides what to do about its own failure, so its error has to
+  // survive the rollback rather than being replaced by one from the plumbing.
+  it("reports the caller's error when a sync reload precedes an abort", async () => {
+    const repo = await SyncedTestRepository.create();
+    const remote = await remoteDbBytes(['remote-1']);
+
+    await expect(
+      repo.transaction(async () => {
+        insertArticleRow(repo, 'local-1');
+        repo.beginSync(remote);
+        await repo.landSync();
+        throw new Error('caller aborted');
+      })
+    ).rejects.toThrow('caller aborted');
+
+    expect(articleIds(repo)).not.toContain('local-1');
+  });
+
+  it('stays writable after a sync reload interrupts a transaction', async () => {
+    const repo = await SyncedTestRepository.create();
+    const remote = await remoteDbBytes(['remote-1']);
+
+    await repo
+      .transaction(async () => {
+        insertArticleRow(repo, 'local-1');
+        repo.beginSync(remote);
+        await repo.landSync();
+      })
+      .catch(() => {});
+
+    insertArticleRow(repo, 'local-2');
+    await repo.settleSaves();
+    expect(await repo.articleIdsOnDisk()).toContain('local-2');
+
+    await repo.transaction(async () => {
+      insertArticleRow(repo, 'local-3');
+    });
+    expect(articleIds(repo)).toContain('local-3');
+  });
+
+  // Subscribers refresh the review queue from these events. An id the reload
+  // discarded would leave the queue showing a row the database does not hold.
+  it('never announces a row the reload discarded', async () => {
+    const repo = await SyncedTestRepository.create();
+    const remote = await remoteDbBytes(['remote-1']);
+    const events: DataChangeEvent[] = [];
+    repo.onDataChange((e) => events.push(e));
+
+    await repo
+      .transaction(async () => {
+        insertArticleRow(repo, 'local-1');
+        repo.beginSync(remote);
+        await repo.landSync();
+        insertArticleRow(repo, 'local-2');
+      })
+      .catch(() => {});
+
+    const present = articleIds(repo);
+    for (const event of events) {
+      for (const id of event.ids) expect(present).toContain(id);
+    }
+  });
+});
+
+describe('external sync while a transaction is open (model-based)', () => {
+  /**
+   * What the caller believes about the open transaction. The real system is a
+   * repository whose database file a second writer is rewriting underneath it.
+   */
+  type SyncModel = {
+    /** Ids the open transaction has written. */
+    txWrites: string[];
+    /** Whether a reload has been triggered and is waiting to land. */
+    syncInFlight: boolean;
+  };
+
+  class InsertArticle
+    implements fc.AsyncCommand<SyncModel, SyncedTestRepository>
+  {
+    constructor(readonly id: string) {}
+    check(model: Readonly<SyncModel>): boolean {
+      // Re-inserting an id violates the UNIQUE reference, which would fail the
+      // transaction for a reason that has nothing to do with sync.
+      return !model.txWrites.includes(this.id);
+    }
+    async run(model: SyncModel, repo: SyncedTestRepository) {
+      insertArticleRow(repo, this.id);
+      model.txWrites.push(this.id);
+    }
+    toString() {
+      return `insert(${this.id})`;
+    }
+  }
+
+  class StartSync implements fc.AsyncCommand<SyncModel, SyncedTestRepository> {
+    constructor(readonly remoteIds: string[]) {}
+    check(model: Readonly<SyncModel>): boolean {
+      return !model.syncInFlight;
+    }
+    async run(model: SyncModel, repo: SyncedTestRepository) {
+      repo.beginSync(await remoteDbBytes(this.remoteIds));
+      model.syncInFlight = true;
+    }
+    toString() {
+      return `startSync(${this.remoteIds.join('+')})`;
+    }
+  }
+
+  class LandSync implements fc.AsyncCommand<SyncModel, SyncedTestRepository> {
+    check(model: Readonly<SyncModel>): boolean {
+      return model.syncInFlight;
+    }
+    async run(model: SyncModel, repo: SyncedTestRepository) {
+      await repo.landSync();
+      model.syncInFlight = false;
+    }
+    toString() {
+      return 'landSync()';
+    }
+  }
+
+  /**
+   * Recorded rather than thrown: throwing here would abort the transaction and
+   * the run would report a rollback instead of the read that went missing.
+   */
+  class ReadBack implements fc.AsyncCommand<SyncModel, SyncedTestRepository> {
+    check(): boolean {
+      return true;
+    }
+    async run(model: SyncModel, repo: SyncedTestRepository) {
+      const present = articleIds(repo);
+      repo.readBackFailures.push(
+        ...model.txWrites.filter((id) => !present.includes(id))
+      );
+    }
+    toString() {
+      return 'readBack()';
+    }
+  }
+
+  const LOCAL_IDS = ['local-1', 'local-2', 'local-3'];
+  const REMOTE_IDS = ['remote-1', 'remote-2'];
+
+  const syncCommands: fc.Arbitrary<
+    fc.AsyncCommand<SyncModel, SyncedTestRepository>
+  >[] = [
+    fc.constantFrom(...LOCAL_IDS).map((id) => new InsertArticle(id)),
+    fc.subarray(REMOTE_IDS, { minLength: 1 }).map((ids) => new StartSync(ids)),
+    fc.constant(new LandSync()),
+    fc.constant(new ReadBack()),
+  ];
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('property: a transaction is all-or-nothing however a sync reload interleaves with it', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.commands(syncCommands, { maxCommands: 6 }),
+        fc.boolean(),
+        async (cmds, callerAborts) => {
+          const repo = await SyncedTestRepository.create();
+          const events: DataChangeEvent[] = [];
+          repo.onDataChange((e) => events.push(e));
+          const model: SyncModel = { txWrites: [], syncInFlight: false };
+
+          let rejected = false;
+          await repo
+            .transaction(async () => {
+              await fc.asyncModelRun(() => ({ model, real: repo }), cmds);
+              if (callerAborts) throw new Error('caller aborted');
+            })
+            .catch(() => {
+              rejected = true;
+            });
+
+          // A reload may still be parked; let it finish so the run settles.
+          await repo.settleSync();
+          const present = articleIds(repo);
+
+          // Only the caller may fail a transaction. A reload arriving
+          // mid-flight is not something the caller can act on.
+          expect(rejected).toBe(callerAborts);
+
+          // Every write, or none of them — never a subset.
+          const applied = model.txWrites.filter((id) => present.includes(id));
+          expect(applied).toEqual(callerAborts ? [] : model.txWrites);
+
+          // An open transaction sees its own writes for as long as it is open.
+          expect(repo.readBackFailures).toEqual([]);
+
+          // A committed transaction reached the file, not just memory.
+          if (!callerAborts) {
+            expect(await repo.articleIdsOnDisk()).toEqual(
+              expect.arrayContaining(model.txWrites)
+            );
+          }
+
+          // No listener hears about a row the database does not hold.
+          for (const event of events) {
+            for (const id of event.ids) expect(present).toContain(id);
+          }
+
+          repo.db?.close();
+        }
+      )
+    );
   });
 });

--- a/src/lib/repository/SQLJSRepository.test.ts
+++ b/src/lib/repository/SQLJSRepository.test.ts
@@ -150,6 +150,24 @@ function articleIds(repo: SQLJSRepository): string[] {
   );
 }
 
+let emptyDbBytes: Uint8Array | null = null;
+
+/**
+ * Bytes of an empty database at the current schema. Executing the schema costs
+ * far more than deserializing the result, and the property below needs a fresh
+ * database per run.
+ */
+async function getEmptyDbBytes(): Promise<Uint8Array> {
+  if (emptyDbBytes) return emptyDbBytes;
+
+  const SQL = await getSharedSql();
+  const db = new SQL.Database();
+  db.exec(getSharedSchema());
+  emptyDbBytes = db.export();
+  db.close();
+  return emptyDbBytes;
+}
+
 const remoteDbCache = new Map<string, Uint8Array>();
 
 /**
@@ -162,8 +180,7 @@ async function remoteDbBytes(ids: readonly string[]): Promise<Uint8Array> {
   if (cached) return cached;
 
   const SQL = await getSharedSql();
-  const db = new SQL.Database();
-  db.exec(getSharedSchema());
+  const db = new SQL.Database(await getEmptyDbBytes());
   for (const id of ids)
     db.exec(INSERT_ARTICLE_SQL, articleRow(id) as SqlValue[]);
   const bytes = db.export();
@@ -218,10 +235,11 @@ class SyncedTestRepository extends SQLJSRepository {
       schema,
     });
     repo.#sqlStatic = SQL;
-    repo.db = new SQL.Database();
-    repo.db.exec(schema);
+    // The file starts out as a valid empty database, so a reload always finds
+    // one, and memory starts out matching it.
+    repo.diskBytes = await getEmptyDbBytes();
+    repo.db = new SQL.Database(repo.diskBytes);
     repo.registerUpdateHook();
-    await repo.save(); // seed the file, so a reload always finds a valid db
     return repo;
   }
 
@@ -249,7 +267,12 @@ class SyncedTestRepository extends SQLJSRepository {
     } as TAbstractFile);
   }
 
-  /** Release the parked read so the reload it belongs to runs to completion. */
+  /**
+   * Release the parked read so the reload it belongs to runs to completion.
+   * A reload the repository held back because a transaction is open has not
+   * issued its read yet, so there is nothing to release and this just waits
+   * out the `modify` handler.
+   */
   async landSync(): Promise<void> {
     // The reload awaits the WASM loader before it reads the file; let those
     // microtasks drain so the read is really parked before releasing it.
@@ -261,9 +284,22 @@ class SyncedTestRepository extends SQLJSRepository {
     this.#inFlightSync = null;
   }
 
-  /** Finish a reload still in flight, so a run ends in a settled state. */
+  /**
+   * Release every read still parked, including one issued by a reload that was
+   * held back until a transaction settled, so a run ends in a settled state.
+   */
   async settleSync(): Promise<void> {
-    if (this.#inFlightSync) await this.landSync();
+    for (let idle = 0; idle < 5; ) {
+      if (this.#parkedReads.length > 0) {
+        this.#parkedReads.shift()?.();
+        idle = 0;
+      } else {
+        idle++;
+      }
+      await Promise.resolve();
+    }
+    await this.#inFlightSync;
+    this.#inFlightSync = null;
   }
 
   /**
@@ -682,6 +718,72 @@ describe('transaction', () => {
 
     expect(events).toEqual([{ table: 'article', op: 'update', ids: ['a1'] }]);
   });
+
+  // A nested call joins the outer transaction, so its writes inherit the same
+  // deferral: nothing reaches disk or listeners until the outermost commits.
+  it("defers a nested transaction's writes to the outermost commit", async () => {
+    const { repo: savingRepo } = await makeSavingRepo();
+    const writeBinary = savingRepo.app.vault.adapter.writeBinary as ReturnType<
+      typeof vi.fn
+    >;
+    const events: DataChangeEvent[] = [];
+    savingRepo.onDataChange((e) => events.push(e));
+
+    await savingRepo.transaction(async () => {
+      await savingRepo.transaction(async () => {
+        savingRepo.mutate(
+          `INSERT INTO article (id, reference, due, interval, priority)
+           VALUES ($1, $2, $3, $4, $5)`,
+          ['a1', 'articles/a1.md', Date.now(), 86_400_000, 30]
+        );
+      });
+      // the inner call returned, but the outer transaction is still open
+      expect(events).toEqual([]);
+      expect(writeBinary).not.toHaveBeenCalled();
+    });
+
+    expect(events).toEqual([{ table: 'article', op: 'insert', ids: ['a1'] }]);
+    expect(writeBinary).toHaveBeenCalledTimes(1);
+  });
+
+  // Miscounting the open-transaction depth leaves the repository permanently
+  // convinced a transaction is running, silently dropping every later write.
+  it('restores normal per-write behavior after a nested transaction commits', async () => {
+    const events: DataChangeEvent[] = [];
+    await repo.transaction(async () => {
+      await repo.transaction(async () => {
+        insertArticle(repo, 'a1');
+      });
+    });
+    repo.onDataChange((e) => events.push(e));
+
+    repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [40, 'a1']);
+
+    expect(events).toEqual([{ table: 'article', op: 'update', ids: ['a1'] }]);
+  });
+
+  it('restores normal per-write behavior after a transaction rolls back', async () => {
+    insertArticle(repo, 'a1', 30);
+    await expect(
+      repo.transaction(async () => {
+        throw new Error('aborted');
+      })
+    ).rejects.toThrow('aborted');
+    const events: DataChangeEvent[] = [];
+    repo.onDataChange((e) => events.push(e));
+
+    repo.mutate(`UPDATE article SET priority = $1 WHERE id = $2`, [40, 'a1']);
+
+    expect(events).toEqual([{ table: 'article', op: 'update', ids: ['a1'] }]);
+  });
+
+  it('rejects when the database is not initialized', async () => {
+    repo.db = null;
+
+    await expect(repo.transaction(async () => 'never')).rejects.toThrow(
+      'Database was not initialized on repository'
+    );
+  });
 });
 
 // On a vault with Obsidian Sync running, a second writer rewrites the database
@@ -790,6 +892,46 @@ describe('external sync while a transaction is open', () => {
     ).rejects.toThrow('caller aborted');
 
     expect(articleIds(repo)).not.toContain('local-1');
+  });
+
+  // Holding a reload back must not mean dropping it — the peer's rows still
+  // have to arrive once the transaction is out of the way. Asserted on the
+  // rollback path, where nothing was saved and the file still holds them.
+  it('applies a held-back sync reload once the transaction settles', async () => {
+    const repo = await SyncedTestRepository.create();
+
+    await expect(
+      repo.transaction(async () => {
+        insertArticleRow(repo, 'local-1');
+        repo.beginSync(await remoteDbBytes(['remote-1']));
+        await repo.landSync();
+        throw new Error('caller aborted');
+      })
+    ).rejects.toThrow('caller aborted');
+
+    await repo.settleSync();
+
+    expect(articleIds(repo)).toEqual(['remote-1']);
+  });
+
+  // The depth counter that holds the reload back is shared with nested calls,
+  // so a reload that arrives inside one must survive until the outermost ends.
+  it('holds a sync reload back for the whole of a nested transaction', async () => {
+    const repo = await SyncedTestRepository.create();
+
+    await repo.transaction(async () => {
+      await repo.transaction(async () => {
+        repo.beginSync(await remoteDbBytes(['remote-1']));
+        await repo.landSync();
+        insertArticleRow(repo, 'local-1');
+      });
+      insertArticleRow(repo, 'local-2');
+    });
+
+    expect(articleIds(repo)).toEqual(
+      expect.arrayContaining(['local-1', 'local-2'])
+    );
+    await repo.settleSync();
   });
 
   it('stays writable after a sync reload interrupts a transaction', async () => {

--- a/src/lib/repository/SQLJSRepository.ts
+++ b/src/lib/repository/SQLJSRepository.ts
@@ -69,6 +69,12 @@ export class SQLJSRepository implements SQLiteRepository {
    * defer saving and change notification to that outermost call.
    */
   #txDepth = 0;
+  /**
+   * Set when a `modify` event for the database file arrives while a
+   * transaction is open, so the reload it asks for can run once that
+   * transaction settles. See {@link handleFileChange}.
+   */
+  #reloadPending = false;
 
   /**
    * Use .start to instantiate
@@ -130,7 +136,21 @@ export class SQLJSRepository implements SQLiteRepository {
     if (this.pendingSaveCount > 0) {
       return;
     }
+    // A reload replaces `this.db` wholesale, which would orphan an open
+    // transaction: its BEGIN belongs to the database being discarded, so the
+    // writes made so far vanish, later ones land outside any transaction, and
+    // the COMMIT fails on a database that never started one. Hold the reload
+    // until the transaction settles — {@link transaction} runs it then.
+    if (this.#txDepth > 0) {
+      this.#reloadPending = true;
+      return;
+    }
 
+    await this.#reloadFromDisk();
+  }
+
+  /** Reload the database file, reporting rather than throwing on failure. */
+  async #reloadFromDisk() {
     try {
       await this.reloadDb();
       await this.onReloadFromDisk?.();
@@ -144,6 +164,18 @@ export class SQLJSRepository implements SQLiteRepository {
         console.error(error);
       }
     }
+  }
+
+  /**
+   * Run a reload that arrived while a transaction was open. Left unawaited to
+   * match how Obsidian dispatches the `modify` event that asks for it: the
+   * transaction is finished either way, and its caller should not wait on a
+   * full re-read of the database file.
+   */
+  #runPendingReload() {
+    if (!this.#reloadPending) return;
+    this.#reloadPending = false;
+    void this.#reloadFromDisk();
   }
 
   /**
@@ -196,6 +228,10 @@ export class SQLJSRepository implements SQLiteRepository {
    * joins the outer one, which alone commits or rolls back. SQLite has no
    * nested transactions, and savepoints would let an inner failure be swallowed
    * while the outer transaction still commits.
+   *
+   * A reload asked for while the transaction was open — by Obsidian Sync
+   * rewriting the database file, say — is held back and run once it settles,
+   * so an external write cannot swap the database out mid-transaction.
    * @returns whatever `work` resolves to
    * @throws whatever `work` throws, after rolling back
    */
@@ -223,12 +259,14 @@ export class SQLJSRepository implements SQLiteRepository {
       // Rolled-back rows were never durable, so their buffered change events
       // must not reach listeners.
       this.#pendingChanges.clear();
+      this.#runPendingReload();
       throw error;
     }
     this.#txDepth--;
     this.db.exec('COMMIT');
     this.#flushChanges();
     await this.save();
+    this.#runPendingReload();
     return result;
   }
 

--- a/src/lib/repository/SQLJSRepository.ts
+++ b/src/lib/repository/SQLJSRepository.ts
@@ -63,6 +63,12 @@ export class SQLJSRepository implements SQLiteRepository {
    * grouped by note type then op. Flushed to listeners once the write finishes.
    */
   #pendingChanges = new Map<NoteType, Map<DataChangeOp, Set<string>>>();
+  /**
+   * How many {@link transaction} calls are currently open. Only the outermost
+   * one issues BEGIN/COMMIT/ROLLBACK; a non-zero depth also tells `mutate` to
+   * defer saving and change notification to that outermost call.
+   */
+  #txDepth = 0;
 
   /**
    * Use .start to instantiate
@@ -153,15 +159,77 @@ export class SQLJSRepository implements SQLiteRepository {
 
   /**
    * Execute a write query
+   *
+   * Unlike {@link query}, a failed write throws rather than resolving to an
+   * empty result: callers cannot otherwise distinguish a rejected write from
+   * one that legitimately returned no rows, and {@link transaction} needs the
+   * failure to decide whether to roll back.
    * @param query
    * @returns an empty array on success
+   * @throws if the statement fails
    */
   mutate(query: string, params: Primitive[] = []) {
+    if (this.#txDepth > 0) {
+      // Inside a transaction the caller owns commit/rollback, so changes are
+      // buffered and flushed there — a statement that is later rolled back
+      // must not notify listeners or reach disk.
+      return this._execSql(query, params, { throwOnError: true }) as [][];
+    }
+
     this.#pendingChanges.clear();
-    const result = this._execSql(query, params);
+    const result = this._execSql(query, params, { throwOnError: true });
     this.#flushChanges();
     void this.save();
     return result as [][];
+  }
+
+  /**
+   * Run `work` inside a SQLite transaction,rolling back if it throws.
+   *
+   * Statements issued by `work` skip the per-statement save and change
+   * notification that {@link mutate} normally performs; both happen once, after
+   * a successful commit, so subscribers never observe rolled-back rows and the
+   * database file is written once per transaction rather than once per
+   * statement.
+   *
+   * Transactions do not nest: a `transaction` call made while another is open
+   * joins the outer one, which alone commits or rolls back. SQLite has no
+   * nested transactions, and savepoints would let an inner failure be swallowed
+   * while the outer transaction still commits.
+   * @returns whatever `work` resolves to
+   * @throws whatever `work` throws, after rolling back
+   */
+  async transaction<T>(work: () => T | Promise<T>): Promise<T> {
+    if (!this.db) throw new Error('Database was not initialized on repository');
+
+    if (this.#txDepth > 0) {
+      this.#txDepth++;
+      try {
+        return await work();
+      } finally {
+        this.#txDepth--;
+      }
+    }
+
+    this.#pendingChanges.clear();
+    this.db.exec('BEGIN');
+    this.#txDepth++;
+    let result: T;
+    try {
+      result = await work();
+    } catch (error) {
+      this.#txDepth--;
+      this.db.exec('ROLLBACK');
+      // Rolled-back rows were never durable, so their buffered change events
+      // must not reach listeners.
+      this.#pendingChanges.clear();
+      throw error;
+    }
+    this.#txDepth--;
+    this.db.exec('COMMIT');
+    this.#flushChanges();
+    await this.save();
+    return result;
   }
 
   /**
@@ -232,12 +300,19 @@ export class SQLJSRepository implements SQLiteRepository {
    * Execute one or more queries and return an array of objects corresponding to table rows.
    * Use `query` or `mutate` methods above instead where possible.
    *
-   *  TODO:
-   * - handle errors better?
    * @param query
+   * @param params
+   * @param options `throwOnError` rethrows a failed statement instead of
+   * resolving to an empty result. Reads leave it off, so the many `query`
+   * callers keep their empty-array fallback; writes turn it on, since a
+   * silently dropped write is indistinguishable from an empty result set.
    * @returns an array where each top-level element is the result of a query
    */
-  _execSql(query: string, params: Primitive[] = []) {
+  _execSql(
+    query: string,
+    params: Primitive[] = [],
+    options?: { throwOnError?: boolean }
+  ) {
     // console.log({ query, params });
     try {
       const results = this.db?.exec(query, this.coerceParams(params));
@@ -254,6 +329,7 @@ export class SQLJSRepository implements SQLiteRepository {
           platform: Platform.isMobile ? 'mobile' : 'desktop',
         });
       }
+      if (options?.throwOnError) throw error;
       return [[]];
     }
   }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -103,6 +103,10 @@ const seenIdsSlice = createSlice({
       }
       state.ids[id] = true;
     },
+    removeSeenId: (state, action: PayloadAction<{ id: string }>) => {
+      const { id } = action.payload;
+      delete state.ids[id];
+    },
     resetSeenIds: (_state, action: PayloadAction<number>) => ({
       ids: {},
       resetTime: action.payload,
@@ -122,7 +126,7 @@ const seenIdsSlice = createSlice({
   },
 });
 
-export const { addSeenId, resetSeenIds } = seenIdsSlice.actions;
+export const { addSeenId, removeSeenId, resetSeenIds } = seenIdsSlice.actions;
 export const { getSeenIds } = seenIdsSlice.selectors;
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,7 +107,7 @@ export type RowTypes =
   | SnippetRow
   | ISnippetReview
   | SRSCardRow
-  | ISRSCardReview;
+  | SRSCardReviewRow;
 
 export interface TableNameToRowType extends Record<TableName, RowTypes> {
   article: ArticleRow;
@@ -115,7 +115,7 @@ export interface TableNameToRowType extends Record<TableName, RowTypes> {
   snippet: SnippetRow;
   snippet_review: ISnippetReview;
   srs_card: SRSCardRow;
-  srs_card_review: ISRSCardReview;
+  srs_card_review: SRSCardReviewRow;
 }
 
 export type ReviewArticle = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -204,10 +204,19 @@ export type DataChangeListener = (event: DataChangeEvent) => void;
 
 export interface SQLiteRepository {
   query(query: string, params?: Primitive[]): RowTypes[] | Promise<RowTypes[]>;
+  /** @throws if the statement fails */
   mutate(query: string, params?: Primitive[]): [][] | Promise<[][]>;
+  /**
+   * Run `work` in a transaction, committing on success and rolling back if it
+   * throws. Change notifications and the save to disk happen once, after the
+   * commit. Nested calls join the outermost transaction.
+   * @throws whatever `work` throws, after rolling back
+   */
+  transaction<T>(work: () => T | Promise<T>): Promise<T>;
   _execSql(
     query: string,
-    params?: Primitive[]
+    params?: Primitive[],
+    options?: { throwOnError?: boolean }
   ): RowTypes[][] | Promise<RowTypes[][]>;
   handleFileChange(file: TAbstractFile): Promise<void>;
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,6 +161,17 @@ export default class IncrementalReadingPlugin extends Plugin {
       },
     });
 
+    this.addCommand({
+      id: 'undo',
+      name: 'Undo last action',
+      checkCallback: (checking: boolean) => {
+        if (!this.reviewManager) return false;
+        if (checking) return true;
+
+        void this.actions.undo();
+      },
+    });
+
     initReviewCommands(this);
 
     this.registerEvent(

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ export default class IncrementalReadingPlugin extends Plugin {
         }
         if (checking) return true;
 
-        void this.reviewManager.createSnippet(editor, view);
+        void this.actions.createSnippet();
       },
     });
 
@@ -91,20 +91,16 @@ export default class IncrementalReadingPlugin extends Plugin {
       checkCallback: (checking) => {
         if (!this.reviewManager) return false;
 
+        const view =
+          this.getActiveReviewView() ??
+          this.app.workspace.getActiveViewOfType(MarkdownView);
+        if (!view) return false;
+
         const editor = this.app.workspace.activeEditor?.editor;
         if (!editor) return false;
         if (checking) return true;
 
-        const reviewView = this.getActiveReviewView();
-        if (reviewView) {
-          void this.reviewManager.createCard(editor, reviewView);
-        }
-
-        const markdownView =
-          this.app.workspace.getActiveViewOfType(MarkdownView);
-        if (markdownView) {
-          void this.reviewManager.createCard(editor, markdownView);
-        }
+        void this.actions.createCard();
       },
     });
 

--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,10 @@
 }
 
 /* Keep Obsidian's accent rule, which now marks the run of transcluded text
-   rather than bounding a block.
+   rather than bounding a block. Used only where the transclusion has no host
+   block to hang the rule off — a standalone `![[…]]`, which CodeMirror renders
+   as its own widget outside any `.cm-line`. There every fragment starts at the
+   same x, so painting per fragment is exact.
 
    No border declaration here on purpose: `.markdown-embed` already sets
    `border-inline-start: var(--embed-border-start, …)`, so the rule follows
@@ -36,15 +39,55 @@
   padding-block: 0.2em;
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
+
+  /* Hand the open-in-tab button's containing block to the host line, so
+     Obsidian's own `top: 4px; inset-inline-end: 4px` lands on one predictable
+     corner.
+ */
+  position: static;
 }
 
-/* The open-in-tab button is absolutely positioned against a box that no longer
-   has corners to pin it to, so it flows as an icon after the snippet instead. */
-.internal-embed[alt*='ir-hide-title'] .markdown-embed-link {
-  display: inline-flex;
-  position: static;
-  vertical-align: middle;
-  padding: 0 var(--size-2-1);
+/* `.cm-line` is already relative in Live Preview. The reading-view hosts are
+   not, so promote them — but only the ones holding a transclusion, since this
+   changes what every absolutely positioned descendant resolves against. */
+.markdown-rendered
+  :is(p, h1, h2, h3, h4, h5, h6, li):has(
+    > .internal-embed[alt*='ir-hide-title']
+  ) {
+  position: relative;
+}
+
+/* Wherever the transclusion does have a host block, paint the rule on the host
+   instead, and drop the per-fragment border below.
+
+   `background-origin: content-box` is the only primitive that resolves to the
+   host's content edge without anyone having to know that padding, so the rule
+   lands in one place no matter how the bullet measures. */
+.markdown-source-view.mod-cm6
+  .cm-line:has(> .internal-embed[alt*='ir-hide-title']),
+.markdown-rendered
+  :is(p, h1, h2, h3, h4, h5, h6, li):has(
+    > .internal-embed[alt*='ir-hide-title']
+  ) {
+  background-image: linear-gradient(
+    var(--interactive-accent),
+    var(--interactive-accent)
+  );
+  background-repeat: no-repeat;
+  background-size: 2px 100%;
+  background-position: 0 0;
+  background-origin: content-box;
+}
+
+.markdown-source-view.mod-cm6
+  .cm-line:has(> .internal-embed[alt*='ir-hide-title'])
+  > .internal-embed[alt*='ir-hide-title'],
+.markdown-rendered
+  :is(p, h1, h2, h3, h4, h5, h6, li):has(
+    > .internal-embed[alt*='ir-hide-title']
+  )
+  > .internal-embed[alt*='ir-hide-title'] {
+  border-inline-start: none;
 }
 
 /* Obsidian indents embedded content by 1.5rem to sit clear of the accent rule.

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,77 @@
-/* Hide titles for transcluded snippets/cards */
-.internal-embed[alt*='ir-hide-title'] .markdown-embed-title {
+/* #region Transcluded snippets/cards */
+
+/* Flatten the tree inline to fit onto the same line in lists */
+.internal-embed[alt*='ir-hide-title'],
+.internal-embed[alt*='ir-hide-title']
+  :is(.markdown-embed-content, .markdown-preview-view, p),
+.internal-embed[alt*='ir-hide-title'] .markdown-preview-section > div,
+/* Gated on the min-height Obsidian writes once its first render pass has
+   measured: the preview renderer measures the sizer to decide what is on
+   screen, and an inline box measures zero, so flipping it any earlier renders
+   the embed empty. */
+.internal-embed[alt*='ir-hide-title']
+  .markdown-preview-sizer[style*='min-height'] {
+  display: inline;
+}
+
+/* The embed's own title and the transcluded note's inline title and properties
+   have nowhere to sit in inline flow — each would interrupt the sentence.
+
+   `.markdown-preview-pusher` stays visible on purpose: it is part of what the
+   renderer measures, and hiding it is not free the way it looks. */
+.internal-embed[alt*='ir-hide-title'] .markdown-embed-title,
+.internal-embed[alt*='ir-hide-title'] .mod-header,
+.internal-embed[alt*='ir-hide-title'] .mod-footer {
   display: none;
 }
+
+/* Keep Obsidian's accent rule, which now marks the run of transcluded text
+   rather than bounding a block.
+
+   No border declaration here on purpose: `.markdown-embed` already sets
+   `border-inline-start: var(--embed-border-start, …)`, so the rule follows
+   whatever the active theme uses for embeds. */
+.internal-embed[alt*='ir-hide-title'] {
+  padding-inline-start: var(--size-4-2);
+  padding-block: 0.2em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+/* The open-in-tab button is absolutely positioned against a box that no longer
+   has corners to pin it to, so it flows as an icon after the snippet instead. */
+.internal-embed[alt*='ir-hide-title'] .markdown-embed-link {
+  display: inline-flex;
+  position: static;
+  vertical-align: middle;
+  padding: 0 var(--size-2-1);
+}
+
+/* Obsidian indents embedded content by 1.5rem to sit clear of the accent rule.
+   That reads as a pull quote, and the `padding-inline-start` above already
+   spaces the text off the rule at inline scale.
+
+   The `> ` chain is load-bearing: the indent comes from
+   `.inline-embed > .markdown-embed-content > .markdown-preview-view`, so a
+   descendant selector here would only tie its specificity and win on source
+   order alone. */
+.internal-embed[alt*='ir-hide-title'] .markdown-embed-content,
+.internal-embed[alt*='ir-hide-title']
+  > .markdown-embed-content
+  > .markdown-preview-view {
+  padding: 0;
+  /* Set to 100% for a scrollable embed box. An inline box has no height to
+     fill, and leaving it set makes the host line measure wrong. */
+  height: auto;
+}
+
+/* `.markdown-preview-view` sets its own font size and line height, so a
+   transclusion inside a heading would otherwise render at body size. */
+.internal-embed[alt*='ir-hide-title'] .markdown-preview-view {
+  font-size: inherit;
+  line-height: inherit;
+}
+/* #endregion */
 
 .workspace-leaf-content[data-type='incremental-reading-review'] .view-content {
   /* to match vanilla styling */

--- a/styles.css
+++ b/styles.css
@@ -62,13 +62,15 @@
 
    `background-origin: content-box` is the only primitive that resolves to the
    host's content edge without anyone having to know that padding, so the rule
-   lands in one place no matter how the bullet measures. */
+   lands in one place no matter how the bullet measures.
+
+   Except where a `<br>` starts the transclusion on its own line (Reading view) */
 .markdown-source-view.mod-cm6
   .cm-line:has(> .internal-embed[alt*='ir-hide-title']),
 .markdown-rendered
   :is(p, h1, h2, h3, h4, h5, h6, li):has(
     > .internal-embed[alt*='ir-hide-title']
-  ) {
+  ):not(:has(> br + .internal-embed[alt*='ir-hide-title'])) {
   background-image: linear-gradient(
     var(--interactive-accent),
     var(--interactive-accent)
@@ -85,7 +87,7 @@
 .markdown-rendered
   :is(p, h1, h2, h3, h4, h5, h6, li):has(
     > .internal-embed[alt*='ir-hide-title']
-  )
+  ):not(:has(> br + .internal-embed[alt*='ir-hide-title']))
   > .internal-embed[alt*='ir-hide-title'] {
   border-inline-start: none;
 }


### PR DESCRIPTION
Adds undoing functionality for creating cards and snippets; and for reviewing, skipping, or dismissing items.

Also:
- Bundles DB operations on reviews into transactions
- Fixes a bug that could cause fetched note text to not match the current item
- Improves styling on embedded cards, to match the appearance of the original text instead of adjusting the indent and adding a blank line above it
- Updates highlights for all views when snippets are deleted
- Fixes a bug where some edits could be lost if a note was modified in review and also modified externally at the same time
- Fixes a bug where review view would jump to the top of a note when the note was modified externally
- Use the latest **desktop** release of Obsidian in CI instead of the latest release to handle cases where the latest version is only released on mobile.